### PR TITLE
Add assignment rubric auto-generation 

### DIFF
--- a/packages/common/types/CS340Types.ts
+++ b/packages/common/types/CS340Types.ts
@@ -31,6 +31,7 @@ export interface SubQuestionGrade {
 export interface AssignmentInfo {
     seedRepoURL: string;
     seedRepoPath: string;
+    mainFilePath: string;
     status: AssignmentStatus;
     rubric: AssignmentGradingRubric;
     repositories: string[];             // Associated Repositories based on IDs
@@ -46,14 +47,14 @@ export interface AssignmentRepositoryInfo {
 // Represents a grading rubric
 export interface AssignmentGradingRubric {
     name: string;
-    comment: string;
+    comment: string; // placeholders for future use
     questions: QuestionGradingRubric[];
 }
 
 // Represents a question rubric
 export interface QuestionGradingRubric {
     name: string;
-    comment: string;
+    comment: string; // placeholders for future use
     subQuestions: SubQuestionGradingRubric[];
 }
 

--- a/packages/portal/backend/src/Factory.ts
+++ b/packages/portal/backend/src/Factory.ts
@@ -29,7 +29,7 @@ export class Factory {
         } else if (name === 'cs310' || name === 'classytest') {
             // no custom routes are required for 310
             return new NoCustomRoutes();
-        } else if (name === 'cs340' || name === 'cpsc340') {
+        } else if (name === 'cs340' || name === 'cpsc340' || name.toLowerCase().startsWith('cpsc340')) {
             return new CS340REST();
         } else {
             Log.error("Factory::getCustomRouteHandler() - unknown name: " + name);

--- a/packages/portal/backend/src/controllers/340/AssignmentController.ts
+++ b/packages/portal/backend/src/controllers/340/AssignmentController.ts
@@ -191,7 +191,7 @@ export class AssignmentController {
             if(typeof personVerification[person.name] === 'undefined') personVerification[person.name] = person;
         }
 
-
+        assignInfo = (await this.db.getDeliverable(delivId) as Deliverable).custom;
         for (const student of allStudents) {
             // verify student is a person in the org, if not, skip it (DATABASE INCONSISTENCY!?)
             if(typeof personVerification[student.githubId] === 'undefined') {
@@ -234,7 +234,6 @@ export class AssignmentController {
             repoName += student.githubId;
             let provisionedRepo = await this.createAssignmentRepo(repoName, delivId, [studentTeam]);
 
-
             if (provisionedRepo !== null) {
                 if (assignInfo.repositories === null || typeof assignInfo.repositories === 'undefined') assignInfo.repositories = [];
                 assignInfo.repositories.push(provisionedRepo.id);
@@ -251,7 +250,7 @@ export class AssignmentController {
         if (!anyError) {
             assignInfo.status = AssignmentStatus.CREATED;
         }
-
+        deliv.custom = assignInfo;
         await this.dc.saveDeliverable(deliv);
         Log.info("AssignmentController::initializeAllRepositories(..) - finish");
         return true;
@@ -322,7 +321,7 @@ export class AssignmentController {
     }
 
     public async publishAllRepositories(delivId: string): Promise<boolean> {
-        Log.info("AssignmentController::publishAllRepositories( " + delivId + ") - start");
+        Log.info("AssignmentController::publishAllRepositories( " + delivId + " ) - start");
         // Log.info("AssignmentController::publishAllRepositories(..)");
         let deliv = await this.dc.getDeliverable(delivId);
         if (deliv.custom === null) {
@@ -357,6 +356,7 @@ export class AssignmentController {
         }
 
         assignInfo.status = AssignmentStatus.RELEASED;
+        deliv.custom = assignInfo;
         await this.dc.saveDeliverable(deliv);
         Log.info("AssignmentController::publishAllRepositories(..) - finish");
         return true;

--- a/packages/portal/backend/src/controllers/340/AssignmentController.ts
+++ b/packages/portal/backend/src/controllers/340/AssignmentController.ts
@@ -127,6 +127,7 @@ export class AssignmentController {
         // retrieve provisioning information
         let seedURL = assignInfo.seedRepoURL;
         let seedPath = assignInfo.seedRepoPath;
+        let mainFilePath = assignInfo.mainFilePath;
 
         // attempt to provision the repository
         let provisionAttempt: boolean;

--- a/packages/portal/backend/src/controllers/340/RubricController.ts
+++ b/packages/portal/backend/src/controllers/340/RubricController.ts
@@ -1,0 +1,223 @@
+import {DatabaseController} from "../DatabaseController";
+import {GradesController} from "../GradesController";
+import {RepositoryController} from "../RepositoryController";
+import {TeamController} from "../TeamController";
+import {DeliverablesController} from "../DeliverablesController";
+import {GitHubController} from "../GitHubController";
+import {PersonController} from "../PersonController";
+import {GitHubActions} from "../GitHubActions";
+import {ScheduleController} from "../ScheduleController";
+import {AssignmentController} from "./AssignmentController";
+import {
+    AssignmentGradingRubric,
+    AssignmentInfo,
+    QuestionGradingRubric,
+    SubQuestionGradingRubric
+} from "../../../../../common/types/CS340Types";
+import * as fs from "fs";
+import * as path from 'path';
+import Log from "../../../../../common/Log"
+import {Deliverable} from "../../Types";
+
+const tmp = require('tmp-promise');
+
+
+
+export class RubricController {
+    private db: DatabaseController = DatabaseController.getInstance();
+    private gc: GradesController = new GradesController();
+    private rc: RepositoryController = new RepositoryController();
+    private tc: TeamController = new TeamController();
+    private dc: DeliverablesController = new DeliverablesController();
+    private ghc: GitHubController = new GitHubController();
+    private pc: PersonController = new PersonController();
+    private gha: GitHubActions = new GitHubActions();
+    private sc: ScheduleController = ScheduleController.getInstance();
+    private ac: AssignmentController = new AssignmentController();
+
+
+    public async parseFile(inputFilePath: string): Promise<AssignmentGradingRubric> {
+        Log.info("RubricController::parseFile() - " + __dirname);
+
+
+        // Log.info("RubricController::parseFile() - ");
+        // Log.info("RubricController::parseFile() - tempPath: " + tempPath);
+
+
+        return null;
+    }
+
+
+    public async updateRubric(assignId: string): Promise<boolean> {
+        Log.info("RubricController::updateRubric( "+ assignId + " ) - start");
+
+        let deliverableRecord: Deliverable = await this.db.getDeliverable(assignId);
+        if (deliverableRecord === null) {
+            Log.error("RubricController::updateRubric(..) - Error:  Unable to find " +
+                "deliverable with id: " + assignId);
+            return false;
+        }
+
+        if (deliverableRecord.custom === null || typeof (deliverableRecord.custom as AssignmentInfo).status === 'undefined') {
+            // Log.error("RubricController::updateRubric(..) - Error: ");
+            Log.error("RubricController::updateRubric(..) - Error: deliverable with id: " +
+                assignId + " is not an assignment");
+            return false;
+        }
+
+        let assignInfo: AssignmentInfo = deliverableRecord.custom;
+
+        const tempDir = await tmp.dir({dir: '/tmp', unsafeCleanup: true});
+        const tempPath = tempDir.path;
+
+        Log.info("RubricController::updateRubric() - cloning");
+        await this.cloneRepo(assignInfo.seedRepoURL, tempPath); // clones the repository to the directory
+
+        let exists: boolean;
+        try {
+            exists = fs.existsSync(path.join(tempPath, assignInfo.mainFilePath));
+            if(exists) {
+                fs.readFile(path.join(tempPath, assignInfo.mainFilePath), async (err, data) => {
+                    // Log.info("RubricController::updateRubric(..) - data: " + data);
+                    let arrayData: string[] = data.toString().split('\n');
+                    // Log.info("RubricController::updateRubric(..) - ");
+                    // create a skeleton framework to fill in the blanks
+                    let newQuestions: QuestionGradingRubric[] = [];
+                    for(let i = 0; i < arrayData.length; i++) {
+                        let regexp: RegExp = /rub(r(ic)?)? *[=:]? *({.*})/;
+                        if(regexp.test(arrayData[i])) {
+                            Log.info("RubricController::updateRubric(..) - rubric found: " + arrayData[i]);
+                            // depends on what kind of file
+                            // check for LaTeX
+                            let latexFileExp: RegExp = /[^.]*\.tex/;
+                            let headerString: string;
+                            let headerExp: RegExp;
+                            if(latexFileExp.test(assignInfo.mainFilePath)) {
+                                // if this is a latex file, use a different exp
+                                headerExp = /(?:sub?:)*section(?:\*?:)?.*/;
+                            } else {
+                                headerExp = /#\s+.*/;
+                            }
+                            let rubricString = arrayData[i];
+                            headerString = this.reverseBack(arrayData, i, headerExp);
+                            Log.info("RubricController::updateRubric(..) - header found: " + headerString);
+
+                            // clean the data
+                            // get only the inside of the rubric
+
+                            let rubricArray: string[] = rubricString.match(/{.*}/);
+                            let subQuestionArray: SubQuestionGradingRubric[] = [];
+                            // check if we actually found a match
+                            // WARN: We only are looking for the first one that matches this string, we
+                            // don't expect something to be the form of {something}{here}
+                            if(rubricArray.length > 0) {
+                                let dirtySubQuestionString: string = rubricArray[0];
+                                // convert to an object
+                                // using https://stackoverflow.com/a/34763398
+                                let cleanSubQuestionString: string = dirtySubQuestionString.replace(
+                                    /(['"])?([a-z0-9A-Z_]+)(['"])?:/g, '"$2": ');
+                                let subQuestionObj = JSON.parse(cleanSubQuestionString);
+                                // now we are able to get the mapping of values
+                                let keyArray: string[] = Object.keys(subQuestionObj);
+                                for(const key of keyArray) {
+                                    // TODO: Look up if this splits anymore
+                                    // the key is the rubric critera, and value is
+                                    // the score that it is out of
+                                    let rawValue = subQuestionObj[key];
+                                    let value: number;
+                                    if (typeof rawValue === 'string') {
+                                        value = Number(rawValue);
+                                    } else {
+                                        value = rawValue;
+                                    }
+
+                                    let newSubquestion: SubQuestionGradingRubric = {
+                                        name: key,
+                                        comment: "",
+                                        outOf: value,
+                                        weight: 1,
+                                        modifiers: null
+                                    };
+
+                                    subQuestionArray.push(newSubquestion);
+                                }
+
+                                // once you get the information
+                                let newQuestion: QuestionGradingRubric = {
+                                    name: headerString,
+                                    comment: "",
+                                    subQuestions: subQuestionArray
+                                };
+
+                                newQuestions.push(newQuestion);
+                            }
+                        } else {
+                            // Log.info("RubricController::updateRubric(..) - skipping lone");
+
+                        }
+                    }
+
+                    let assignGradingRubric: AssignmentGradingRubric = {
+                        name: assignInfo.rubric.name,
+                        comment: assignInfo.rubric.comment,
+                        questions: newQuestions
+                    };
+
+                    assignInfo.rubric = assignGradingRubric;
+
+                    deliverableRecord.custom = assignInfo;
+
+                    await this.db.writeDeliverable(deliverableRecord);
+
+                    return true;
+                });
+                // let lineReader = require('readline').createInterface({
+                //     input: fs.createReadStream(path.join(tempPath, assignInfo.mainFilePath))
+                // });
+
+                // linereader.on('line',)
+
+            } else {
+                Log.error("RubricController::updateRubric(..) - main file does not exist in repo");
+                return false;
+            }
+        } catch (err) {
+            Log.error("RubricController::updateRubric(..) - Error: " + err);
+        }
+
+        Log.info("RubricController::updateRubric() - result: " + exists);
+
+        return false;
+    }
+
+    /**
+     * searches backwards through the data starting at the index, for the regex supplied
+     * @param data
+     * @param index
+     * @param regexp
+     */
+    private reverseBack(data: string[], index: number, regexp: RegExp): string {
+        for(let i = index; i >= 0; i--) {
+            if(regexp.test(data[i])) {
+                return data[i];
+            }
+        }
+        return "";
+    }
+
+
+    private async cloneRepo(repoUrl: string, repoPath: string) {
+        const exec = require('child-process-promise').exec;
+        let authedRepo: string = await this.gha.addGithubAuthToken(repoUrl);
+        Log.info('RubricController::cloneRepo(..) - cloning from: ' + repoUrl);
+        return exec(`git clone ${authedRepo} ${repoPath}`)
+            .then(function(result: any) {
+                Log.info('GithubManager::writeFileToRepo(..)::cloneRepo() - done:');
+                Log.trace('GithubManager::writeFileToRepo(..)::cloneRepo() - stdout: ' + result.stdout);
+                if (result.stderr) {
+                    Log.warn('GithubManager::writeFileToRepo(..)::cloneRepo() - stderr: ' + result.stderr);
+                }
+            });
+    }
+
+}

--- a/packages/portal/backend/src/controllers/340/RubricController.ts
+++ b/packages/portal/backend/src/controllers/340/RubricController.ts
@@ -92,19 +92,28 @@ export class RubricController {
                             let latexFileExp: RegExp = /[^.]*\.tex/;
                             let headerString: string;
                             let headerExp: RegExp;
+                            let headerCleaner: RegExp;
                             if(latexFileExp.test(assignInfo.mainFilePath)) {
                                 // if this is a latex file, use a different exp
                                 headerExp = /(?:sub?:)*section(?:\*?:)?.*/;
+                                headerCleaner = /[{}]/g;
                             } else {
                                 headerExp = /#\s+.*/;
+                                headerCleaner = /(#+\s+)/;
                             }
                             let rubricString = arrayData[i];
                             headerString = this.reverseBack(arrayData, i, headerExp);
                             Log.info("RubricController::updateRubric(..) - header found: " + headerString);
 
+                            // clean up the header;
+                            let cleanedHeader: string;
+                            cleanedHeader = headerString.replace(headerCleaner, "");
+
+                            Log.info("RubricController::updateRubric(..) - cleaned header: " +
+                                cleanedHeader);
+
                             // clean the data
                             // get only the inside of the rubric
-
                             let rubricArray: string[] = rubricString.match(/{.*}/);
                             let subQuestionArray: SubQuestionGradingRubric[] = [];
                             // check if we actually found a match
@@ -126,7 +135,12 @@ export class RubricController {
                                     let rawValue = subQuestionObj[key];
                                     let value: number;
                                     if (typeof rawValue === 'string') {
-                                        value = Number(rawValue);
+                                        try {
+                                            value = Number(rawValue);
+                                        } catch (err) {
+                                            Log.error("RubricController::updateRubric(..)::readFile(..) - error " +
+                                                "casting " + rawValue + " to a number; error: " + err);
+                                        }
                                     } else {
                                         value = rawValue;
                                     }
@@ -144,7 +158,7 @@ export class RubricController {
 
                                 // once you get the information
                                 let newQuestion: QuestionGradingRubric = {
-                                    name: headerString,
+                                    name: cleanedHeader,
                                     comment: "",
                                     subQuestions: subQuestionArray
                                 };

--- a/packages/portal/backend/src/controllers/GitHubActions.ts
+++ b/packages/portal/backend/src/controllers/GitHubActions.ts
@@ -865,6 +865,14 @@ export class GitHubActions {
         });
     }
 
+    public addGithubAuthToken(url: string) {
+        let start_append = url.indexOf('//') + 2;
+        let token = this.gitHubAuthToken;
+        let authKey = token.substr(token.indexOf('token ') + 6) + '@';
+        // creates "longokenstring@githuburi"
+        return url.slice(0, start_append) + authKey + url.slice(start_append);
+    }
+
     /**
      * Adds a file with the data given, to the specified repository.
      * If force is set to true, will overwrite old files
@@ -880,20 +888,13 @@ export class GitHubActions {
             " , "+fileContent+" , "+force+" ) - start");
         const that = this;
 
-        // TAKEN FROM importFS ----
-        function addGithubAuthToken(url: string) {
-            let start_append = url.indexOf('//') + 2;
-            let token = that.gitHubAuthToken;
-            let authKey = token.substr(token.indexOf('token ') + 6) + '@';
-            // creates "longokenstring@githuburi"
-            return url.slice(0, start_append) + authKey + url.slice(start_append);
-        }
+        // TAKEN FROM importFS
 
         // generate temp path
         const exec = require('child-process-promise').exec;
         const tempDir = await tmp.dir({dir: '/tmp', unsafeCleanup: true});
         const tempPath = tempDir.path;
-        const authedRepo = addGithubAuthToken(repoURL);
+        const authedRepo = this.addGithubAuthToken(repoURL);
 
 
         // clone repository

--- a/packages/portal/backend/src/controllers/ScheduleController.ts
+++ b/packages/portal/backend/src/controllers/ScheduleController.ts
@@ -145,7 +145,7 @@ export class ScheduleController {
      */
 
     public async createAssignmentTasks(assignId: string): Promise<boolean> {
-        Log.info("AssignmentController::createAssignmentTasks( " + assignId + " ) - start");
+        Log.info("ScheduleController::createAssignmentTasks( " + assignId + " ) - start");
 
         const CREATE_OFFSET_HOURS = 2;
 
@@ -153,12 +153,12 @@ export class ScheduleController {
 
         let deliv: Deliverable = await db.getDeliverable(assignId);
         if(deliv === null) {
-            Log.error("AssignmentController::createAssignmentTasks(..) - Error: no deliverable found with id: " + assignId);
+            Log.error("ScheduleController::createAssignmentTasks(..) - Error: no deliverable found with id: " + assignId);
             return false;
         }
 
         if(deliv.custom === null || typeof deliv.custom === 'undefined' || typeof deliv.custom.seedRepoURL === 'undefined') {
-            Log.error("AssignmentController::createAssignmentTasks(..) - Error: deliv: " + assignId + " is not an assignment");
+            Log.error("ScheduleController::createAssignmentTasks(..) - Error: deliv: " + assignId + " is not an assignment");
             return false;
         }
 
@@ -171,28 +171,34 @@ export class ScheduleController {
 
         let created = false;
         let currentDate: Date = new Date();
-        if(createDate < currentDate && !this.getTask("CREATE_" + assignId)) {
-            Log.info("AssignmentController::createAssignmentTasks(..) - Making create repo task");
+        if(createDate > currentDate) {
+            if (this.getTask("CREATE_" + assignId) === null) {
+                created = true;
+            }
+            Log.info("ScheduleController::createAssignmentTasks(..) - Making create repo task");
             await sc.scheduleAssignmentCreation(createDate, assignId);
-            Log.info("AssignmentController::createAssignmentTasks(..) - Task will execute at: " + createDate.toISOString());
-            created = true;
+            Log.info("ScheduleController::createAssignmentTasks(..) - Task will execute at: " + createDate.toISOString());
         }
 
-        if(openDate < currentDate && !this.getTask("OPEN_" + assignId)) {
-            Log.info("AssignmentController::createAssignmentTasks(..) - Making publish repo task");
+        if(openDate > currentDate) {
+            if (this.getTask("OPEN_" + assignId) === null) {
+                created = true;
+            }
+            Log.info("ScheduleController::createAssignmentTasks(..) - Making publish repo task");
             await sc.scheduleAssignmentPublish(openDate, assignId);
-            Log.info("AssignmentController::createAssignmentTasks(..) - Task will execute at: " + openDate.toISOString());
-            created = true;
+            Log.info("ScheduleController::createAssignmentTasks(..) - Task will execute at: " + openDate.toISOString());
         }
 
-        if(closeDate < currentDate && !this.getTask("CLOSE_" + assignId)) {
-            Log.info("AssignmentController::createAssignmentTasks(..) - Making close repo task");
+        if(closeDate > currentDate) {
+            if (this.getTask("CLOSE_" + assignId) === null) {
+                created = true;
+            }
+            Log.info("ScheduleController::createAssignmentTasks(..) - Making close repo task");
             await sc.scheduleAssignmentClosure(closeDate, assignId);
-            Log.info("AssignmentController::createAssignmentTasks(..) - Task will execute at: " +  closeDate.toISOString());
-            created = true;
+            Log.info("ScheduleController::createAssignmentTasks(..) - Task will execute at: " +  closeDate.toISOString());
         }
 
-        Log.info("AssignmentController::createAssignmentTasks(..) - Current date is: " + currentDate.toISOString());
+        Log.info("ScheduleController::createAssignmentTasks(..) - Current date is: " + currentDate.toISOString());
 
         return created;
     }

--- a/packages/portal/backend/src/server/340/CS340REST.ts
+++ b/packages/portal/backend/src/server/340/CS340REST.ts
@@ -426,7 +426,7 @@ export default class CS340REST implements IREST {
         let delivid: string = req.params.delivid;
 
         let assignController: AssignmentController = new AssignmentController();
-        let newResult = await assignController.getAssignmentStatus(delivid);
+        let newResult = await assignController.updateAssignmentStatus(delivid);
         if (newResult === null) {
             res.send(400, {error: "Assignment not initialized properly"});
         } else {

--- a/packages/portal/backend/src/server/340/CS340REST.ts
+++ b/packages/portal/backend/src/server/340/CS340REST.ts
@@ -8,6 +8,7 @@ import {AssignmentController} from "../../controllers/340/AssignmentController";
 import {AssignmentGrade, AssignmentGradingRubric, AssignmentInfo, QuestionGrade} from "../../../../../common/types/CS340Types";
 import {GradesController} from "../../controllers/GradesController";
 import {PersonController} from "../../controllers/PersonController";
+import {RubricController} from "../../controllers/340/RubricController";
 
 export default class CS340REST implements IREST {
     public constructor() {
@@ -39,6 +40,34 @@ export default class CS340REST implements IREST {
         server.get('/portal/cs340/testPublishAllGrades', CS340REST.testPublishAllGrades);
         server.post('/portal/cs340/verifyScheduledJobs/:aid', CS340REST.verifyScheduledJobs);
         server.post('/portal/cs340/verifyScheduledJobs/', CS340REST.verifyAllScheduledJobs);
+        server.get('/portal/cs340/testRubricParser', CS340REST.testRubricParser);
+    }
+
+
+    public static async testPublishGrade(req: any, res: any, next: any) {
+        let ac: AssignmentController = new AssignmentController();
+        let success = await ac.publishGrade("jopika_grades", "a2_grades", "jopika", "a2");
+        if(success) {
+            res.send(200, "Complete!");
+        } else {
+            res.send(400, "Failed :(");
+        }
+    }
+
+    public static async testPublishAllGrades(req: any, res: any, next: any) {
+        let ac: AssignmentController = new AssignmentController();
+        let success = await ac.publishAllGrades("a2");
+        if(success) {
+            res.send(200, "Complete!");
+        } else {
+            res.send(400, "Failed :(");
+        }
+    }
+
+    public static async testRubricParser(req: any, res: any, next: any) {
+        let rc: RubricController = new RubricController();
+        await rc.updateRubric("a1");
+        res.send(200, "complete!");
     }
 
     public static async verifyAllScheduledJobs(req: any, res: any, next: any) {
@@ -89,26 +118,6 @@ export default class CS340REST implements IREST {
         return next();
     }
 
-
-    public static async testPublishGrade(req: any, res: any, next: any) {
-        let ac: AssignmentController = new AssignmentController();
-        let success = await ac.publishGrade("jopika_grades", "a2_grades", "jopika", "a2");
-        if(success) {
-            res.send(200, "Complete!");
-        } else {
-            res.send(400, "Failed :(");
-        }
-    }
-
-    public static async testPublishAllGrades(req: any, res: any, next: any) {
-        let ac: AssignmentController = new AssignmentController();
-        let success = await ac.publishAllGrades("a2");
-        if(success) {
-            res.send(200, "Complete!");
-        } else {
-            res.send(400, "Failed :(");
-        }
-    }
 
     public static getAssignmentGrade(req: any, res: any, next: any) {
         // TODO [Jonathan]: Get the grade of the student

--- a/packages/portal/backend/test/GlobalSpec.ts
+++ b/packages/portal/backend/test/GlobalSpec.ts
@@ -293,6 +293,7 @@ export class Test {
         let newAssignmentInfo: AssignmentInfo = {
             seedRepoURL:  "https://github.com/SECapstone/capstone",
             seedRepoPath: "",
+            mainFilePath: "",
             status:       newAssignmentStatus,
             rubric:       newAssignmentGradingRubric,
             repositories: []

--- a/packages/portal/frontend/html/cs340/admin.html
+++ b/packages/portal/frontend/html/cs340/admin.html
@@ -179,12 +179,12 @@
                     <div class="center">
                         Selected Deliverable:
                         <select id="adminActionDeliverableSelect" style="margin-left: 1em; margin-right: 1em;"></select>
-                        <ons-button id="adminActionSelectDeliverable" modifier="medium">Select Deliverable</ons-button>
+                        <!--<ons-button id="adminActionSelectDeliverable" modifier="medium">Select Deliverable</ons-button>-->
                         <p id="adminActionDeliverableID" style="margin-left: 1em; font-weight: bold;"></p>
-                        <p id="adminActionStatusText" style="margin-right: 1em;width: 6.5em;"></p>
-                        <ons-button id="adminCheckStatus" style="margin-left: 1em; margin-right: 1em;" disabled="true">
-                            Recalculate Status
-                        </ons-button>
+                        <p id="adminActionStatusText" style="margin-right: 1em/*;width: 6.5em*/;"></p>
+                        <!--<ons-button id="adminCheckStatus" style="margin-left: 1em; margin-right: 1em;" disabled="true">-->
+                            <!--Recalculate Status-->
+                        <!--</ons-button>-->
                         <ons-button id="adminCreateRepositories" disabled="true">Create Repositories</ons-button>
                         <ons-button id="adminReleaseRepositories" style="margin-left: 1em" disabled="true">Release
                             Repositories
@@ -415,7 +415,7 @@
                         </div>
                         <div class="center settingLabel">
                             <span
-                                title="Enable if Students are allowed to creat their own team.">Students Make Teams</span>
+                                title="Enable if Students are allowed to create their own team.">Students Make Teams</span>
                         </div>
                         <div class="right settingRight">
                             <ons-switch id="adminEditDeliverablePage-studentsMakeTeams" modifier="list-item"
@@ -437,6 +437,36 @@
                                         onclick=""></ons-switch>
                         </div>
                     </ons-list-item>
+
+                    <ons-list-header id="adminEditDeliverablePage-assignmentStatusHeader" hidden>
+                        Assignment Status
+                    </ons-list-header>
+
+                    <div id="adminEditDeliverablePage-assignmentStatus">
+                    <ons-list-item style="display: flex;">
+                        <div class="center settingLabel"><span>Repositories Created:</span></div>
+                        <div class="right settingRight">
+                            <ons-switch disabled id="adminEditDeliverablePage-createdSwitch" modifier="list-item"
+                                        onclick=""></ons-switch>
+                        </div>
+                    </ons-list-item>
+
+                    <ons-list-item style="display: flex;">
+                        <div class="center settingLabel"><span>Repository Read Access:</span></div>
+                        <div class="right settingRight">
+                            <ons-switch disabled id="adminEditDeliverablePage-readSwitch" modifier="list-item"
+                                        onclick=""></ons-switch>
+                        </div>
+                    </ons-list-item>
+
+                    <ons-list-item style="display: flex;">
+                        <div class="center settingLabel"><span>Repository Push Access:</span></div>
+                        <div class="right settingRight">
+                            <ons-switch disabled id="adminEditDeliverablePage-pushSwitch" modifier="list-item"
+                                        onclick=""></ons-switch>
+                        </div>
+                    </ons-list-item>
+                    </div>
 
 
                     <ons-list-header>AutoTest Options</ons-list-header>

--- a/packages/portal/frontend/src/app/Factory.ts
+++ b/packages/portal/frontend/src/app/Factory.ts
@@ -139,7 +139,7 @@ export class Factory {
             return 'sdmm';
         } else if (this.name === 'cs310') {
             return 'cs310';
-        } else if (this.name === 'cs340' || this.name === 'cpsc340') {
+        } else if (this.name === 'cs340' || this.name === 'cpsc340' || this.name.toLowerCase().startsWith('cpsc340')) {
             return 'cs340';
         } else {
             Log.error("Factory::getHTMLPrefix() - ERROR; unknown name: " + this.name);

--- a/packages/portal/frontend/src/app/views/340/CS340AdminView.ts
+++ b/packages/portal/frontend/src/app/views/340/CS340AdminView.ts
@@ -204,13 +204,11 @@ export class CS340AdminView extends AdminView {
         //     // set the switches
         //
         // }
-
-
     }
 
     protected async newSave() {
         // await super.deliverablesTab.save();
-        super.deliverablesTab.save();
+        // super.deliverablesTab.save();
         let number = await this.verifyScheduledJobs(null);
         Log.info("CS340AdminView::newSave() - tasks generated: " + number);
     }


### PR DESCRIPTION
This part of code allows for the ability to generate rubrics by parsing a lab's README (or main file).

Advantages to this method is that it prevents duplication of data (having the rubric specified in two locations). 

This method is optional, and can be skipped by not specifying the file to parse. 