### PR TITLE
Add pre-commit hook to check build and lint status

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+
+yarn lint && yarn build

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "restify": "^6.3.4"
     },
     "scripts": {
+        "postinstall": "git config core.hooksPath .githooks",
         "build": "tsc",
         "build:prod": "tsc --outDir bin --sourceMap false",
         "lintOLD": "tslint -c tslint.json 'packages/portal/backend/src/**/*.ts' 'packages/portal/backend/test/**/*.ts' 'packages/portal/frontend/src/**/*.ts' 'packages/portal/frontend/test/**/*.ts' 'packages/autotest/src/**/*.ts' 'packages/autotest/test/**/*.ts'",


### PR DESCRIPTION
Run `yarn install` to install the hook. To skip, use `--no-verify` with git commit.