### PR TITLE
Select and build Docker images from Portal

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -185,6 +185,8 @@ HOST_SSL_KEY_PATH=/opt/classy/ssl/privkey.pem
 ## GitHub token with read access to clone repositories in the org for the particular course offering
 COURSE_GH_ORG_TOKEN=asb865...
 
+## GitHub token with permission to clone the repository containing the Dockerfile for the grading container
+GH_DOCKER_TOKEN=asb865...
 
 ## [310/SDMM Only] A single hosts entry used to resolve the hostname of the server running geolocation.
 ## This is required since the grading container will not be able to make DNS requests.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@types/mocha": "2.2.44",
         "@types/mongodb": "^3.0.5",
         "@types/node": "8.0.56",
+        "@types/request": "2.48.1",
         "@types/request-promise-native": "^1.0.11",
         "@types/restify": "^5.0.7",
         "chai": "4.1.2",

--- a/packages/autotest/src/autotest/AutoTest.ts
+++ b/packages/autotest/src/autotest/AutoTest.ts
@@ -36,36 +36,17 @@ export interface IAutoTest {
 export abstract class AutoTest implements IAutoTest {
     protected readonly dataStore: IDataStore;
     protected readonly classPortal: IClassPortal = null;
+    protected readonly docker: Docker;
 
     private regressionQueue = new Queue('regression', 1);
     private standardQueue = new Queue('standard', 2);
     private expressQueue = new Queue('express', 1);
-    private readonly docker: Docker;
 
     // noinspection TypeScriptAbstractClassConstructorCanBeMadeProtected
-    constructor(dataStore: IDataStore, classPortal: IClassPortal) {
+    constructor(dataStore: IDataStore, classPortal: IClassPortal, docker: Docker) {
         this.dataStore = dataStore;
         this.classPortal = classPortal;
-
-        if (Config.getInstance().getProp(ConfigKey.name) === "classytest") {
-            // Running tests; don't need to connect to the Docker daemon
-            this.docker = null;
-        } else {
-            const dockerHost = Config.getInstance().getProp(ConfigKey.dockerHost);
-            if (dockerHost !== null && (dockerHost.startsWith("https") || dockerHost.startsWith("http") || dockerHost.startsWith("tcp"))) {
-                const dockerUrl = new URL(dockerHost);
-                this.docker = new Docker({
-                    host: dockerUrl.hostname,
-                    port: dockerUrl.port,
-                    ca: fs.readFileSync("/etc/ssl/certs/ca-certificates.crt"),
-                    cert: fs.readFileSync(Config.getInstance().getProp(ConfigKey.sslCertPath)),
-                    key: fs.readFileSync(Config.getInstance().getProp(ConfigKey.sslKeyPath)),
-                    version: "v1.30"
-                });
-            } else {
-                this.docker = new Docker();
-            }
-        }
+        this.docker = docker;
     }
 
     public addToStandardQueue(input: ContainerInput): void {

--- a/packages/autotest/src/github/GitHubAutoTest.ts
+++ b/packages/autotest/src/github/GitHubAutoTest.ts
@@ -12,6 +12,7 @@ import {
 import Util from "../../../common/Util";
 import {AutoTest} from "../autotest/AutoTest";
 
+import * as Docker from "dockerode";
 import {IClassPortal} from "../autotest/ClassPortal";
 import {IDataStore} from "../autotest/DataStore";
 import {GitHubService, IGitHubMessage} from "./GitHubService";
@@ -39,8 +40,8 @@ export class GitHubAutoTest extends AutoTest implements IGitHubTestManager {
 
     // private github: IGitHubService = null;
 
-    constructor(dataStore: IDataStore, portal: IClassPortal) {
-        super(dataStore, portal);
+    constructor(dataStore: IDataStore, portal: IClassPortal, docker: Docker) {
+        super(dataStore, portal, docker);
         // this.github = github;
     }
 

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -154,12 +154,10 @@ export default class RouteHandler {
         const token = Config.getInstance().getProp(ConfigKey.githubDockerToken);
         try {
             const body = req.body;
-            const t = body.tag;
-            let remote = body.remote;
-            if (token) {
-                remote = remote.replace("https://", "https://" + token + "@");
-            }
-            const stream = await docker.buildImage(null, {remote, t});
+            const remote = token ? body.remote.replace("https://", "https://" + token + "@") : body.remote;
+            const tag = body.tag;
+            const file = body.file;
+            const stream = await docker.buildImage(null, {remote, t: tag, dockerfile: file});
             stream.on("error", (err: Error) => {
                 Log.error("Error building image. " + err.message);
                 res.send(500, "Error building image. " + err.message);
@@ -169,6 +167,7 @@ export default class RouteHandler {
             });
             stream.pipe(res);
         } catch (err) {
+            Log.error("RouteHandler::postDockerImage(..) - ERROR Building docker image: " + err.message);
             res.send(err.statusCode, err.message);
         }
 

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -151,10 +151,14 @@ export default class RouteHandler {
 
     public static async postDockerImage(req: restify.Request, res: restify.Response, next: restify.Next) {
         const docker = RouteHandler.getDocker();
+        const token = Config.getInstance().getProp(ConfigKey.githubDockerToken);
         try {
             const body = req.body;
-            const remote = body.remote;
             const t = body.tag;
+            let remote = body.remote;
+            if (token) {
+                remote = remote.replace("https://", "https://" + token + "@");
+            }
             const stream = await docker.buildImage(null, {remote, t});
             stream.on("error", (err: Error) => {
                 Log.error("Error building image. " + err.message);

--- a/packages/autotest/src/server/Server.ts
+++ b/packages/autotest/src/server/Server.ts
@@ -75,7 +75,7 @@ export default class Server {
                 that.rest.post("/githubWebhook", restify.plugins.bodyParser(), RouteHandler.postGithubHook);
 
                 that.rest.post("/docker/image", restify.plugins.bodyParser(), RouteHandler.postDockerImage);
-                that.rest.get("/docker/images", restify.plugins.bodyParser(), RouteHandler.getDockerImages);
+                that.rest.get("/docker/images", restify.plugins.queryParser(), RouteHandler.getDockerImages);
 
                 // Resource endpoint
                 that.rest.get("/resource/.*", restify.plugins.bodyParser(), RouteHandler.getResource);

--- a/packages/autotest/src/server/Server.ts
+++ b/packages/autotest/src/server/Server.ts
@@ -74,6 +74,9 @@ export default class Server {
                 // GitHub Webhook endpoint
                 that.rest.post("/githubWebhook", restify.plugins.bodyParser(), RouteHandler.postGithubHook);
 
+                that.rest.post("/docker/image", restify.plugins.bodyParser(), RouteHandler.postDockerImage);
+                that.rest.get("/docker/images", restify.plugins.bodyParser(), RouteHandler.getDockerImages);
+
                 // Resource endpoint
                 that.rest.get("/resource/.*", restify.plugins.bodyParser(), RouteHandler.getResource);
 

--- a/packages/autotest/test/GitHubAutoTestSpec.ts
+++ b/packages/autotest/test/GitHubAutoTestSpec.ts
@@ -62,7 +62,7 @@ describe("GitHubAutoTest", () => {
         await data.clearData();
 
         // create a new AutoTest every test (allows us to mess with methods and make sure they are called)
-        at = new GitHubAutoTest(data, portal); // , gh);
+        at = new GitHubAutoTest(data, portal, null); // , gh);
     });
 
     afterEach(async function() {

--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -37,7 +37,7 @@ export enum ConfigKey {
     githubAPI = "githubAPI",
     githubBotName = "githubBotName",
     githubBotToken = "githubBotToken",
-
+    githubDockerToken = "githubDockerToken",
     githubClientId = "githubClientId",
     githubClientSecret = "githubClientSecret",
     githubHost = "githubHost",
@@ -109,6 +109,7 @@ export default class Config {
                 githubBotToken:     process.env.GH_BOT_TOKEN,
                 githubClientId:     process.env.GH_CLIENT_ID,
                 githubClientSecret: process.env.GH_CLIENT_SECRET,
+                githubDockerToken:  process.env.GH_DOCKER_TOKEN,
 
                 autotestUrl:    process.env.AUTOTEST_URL,
                 autotestPort:   process.env.AUTOTEST_PORT,

--- a/packages/portal/backend/src/server/common/AdminRoutes.ts
+++ b/packages/portal/backend/src/server/common/AdminRoutes.ts
@@ -67,12 +67,9 @@ export default class AdminRoutes implements IREST {
         server.post('/portal/admin/provision', AdminRoutes.isAdmin, AdminRoutes.postProvision);
         server.post('/portal/admin/release', AdminRoutes.isAdmin, AdminRoutes.postRelease);
         server.post('/portal/admin/withdraw', AdminRoutes.isAdmin, AdminRoutes.postWithdraw);
-        server.post('/portal/admin/image', AdminRoutes.isAdmin, AdminRoutes.postDockerImage);
         server.del('/portal/admin/deliverable/:delivId', AdminRoutes.isAdmin, AdminRoutes.deleteDeliverable);
         server.del('/portal/admin/repository/:repoId', AdminRoutes.isAdmin, AdminRoutes.deleteRepository);
         server.del('/portal/admin/team/:teamId', AdminRoutes.isAdmin, AdminRoutes.deleteTeam);
-
-        server.get('portal/admin/images', AdminRoutes.isAdmin, AdminRoutes.getDockerImages);
 
         // TODO: unrelease repos
 
@@ -824,37 +821,5 @@ export default class AdminRoutes implements IREST {
 
         Log.info('AdminRoutes::performPostTeam(..) - team created: ' + team.id);
         return teamTrans;
-    }
-
-    public static async getDockerImages(req: restify.Request, res: restify.Response, next: restify.Next) {
-        // TODO @nickbradley handle Docker creation properly!
-        const docker = new Docker();
-        const images = await docker.listImages();
-        res.send(200, images);
-
-        return next();
-    }
-
-    public static async postDockerImage(req: restify.Request, res: restify.Response, next: restify.Next) {
-        // TODO @nickbradley handle Docker creation properly!
-        const docker = new Docker();
-        try {
-            const body = req.body;
-            const remote = body.remote;
-            const t = body.tag;
-            const stream = await docker.buildImage(null, {remote, t});
-            stream.on("error", (err: Error) => {
-                Log.error("Error building image. " + err.message);
-                res.send(500, "Error building image. " + err.message);
-            });
-            stream.on("end", () => {
-                Log.info("Finished building image.");
-            });
-            stream.pipe(res);
-        } catch (err) {
-            res.send(err.statusCode, err.message);
-        }
-
-        return next();
     }
 }

--- a/packages/portal/backend/src/server/common/AdminRoutes.ts
+++ b/packages/portal/backend/src/server/common/AdminRoutes.ts
@@ -34,6 +34,8 @@ import {AuditLabel, Person} from "../../Types";
 import IREST from "../IREST";
 import {CSVParser} from "./CSVParser";
 
+import * as Docker from "dockerode";
+
 export default class AdminRoutes implements IREST {
 
     private static ghc = new GitHubController(GitHubActions.getInstance());
@@ -68,6 +70,8 @@ export default class AdminRoutes implements IREST {
         server.del('/portal/admin/deliverable/:delivId', AdminRoutes.isAdmin, AdminRoutes.deleteDeliverable);
         server.del('/portal/admin/repository/:repoId', AdminRoutes.isAdmin, AdminRoutes.deleteRepository);
         server.del('/portal/admin/team/:teamId', AdminRoutes.isAdmin, AdminRoutes.deleteTeam);
+
+        server.get('portal/admin/images', AdminRoutes.isAdmin, AdminRoutes.getDockerImages);
 
         // TODO: unrelease repos
 
@@ -819,6 +823,15 @@ export default class AdminRoutes implements IREST {
 
         Log.info('AdminRoutes::performPostTeam(..) - team created: ' + team.id);
         return teamTrans;
+    }
+
+    public static async getDockerImages(req: restify.Request, res: restify.Response, next: restify.Next) {
+        // TODO @nickbradley handle Docker creation properly!
+        const docker = new Docker();
+        const images = await docker.listImages();
+        res.send(200, images);
+
+        return next();
     }
 
 }

--- a/packages/portal/backend/src/server/common/AdminRoutes.ts
+++ b/packages/portal/backend/src/server/common/AdminRoutes.ts
@@ -34,8 +34,6 @@ import {AuditLabel, Person} from "../../Types";
 import IREST from "../IREST";
 import {CSVParser} from "./CSVParser";
 
-import * as Docker from "dockerode";
-
 export default class AdminRoutes implements IREST {
 
     private static ghc = new GitHubController(GitHubActions.getInstance());

--- a/packages/portal/backend/src/server/common/AutoTestRoutes.ts
+++ b/packages/portal/backend/src/server/common/AutoTestRoutes.ts
@@ -452,7 +452,7 @@ export class AutoTestRoutes implements IREST {
             const config = Config.getInstance();
 
             const atHost = config.getProp(ConfigKey.autotestUrl);
-            const url = atHost + ':' + config.getProp(ConfigKey.autotestPort) + '/docker/images';
+            const url = atHost + ':' + config.getProp(ConfigKey.autotestPort) + req.href().replace("/portal/at", "");
             const options = {
                 uri:     url,
                 method:  'GET',

--- a/packages/portal/backend/src/server/common/AutoTestRoutes.ts
+++ b/packages/portal/backend/src/server/common/AutoTestRoutes.ts
@@ -1,3 +1,4 @@
+import * as request from "request";
 import * as rp from "request-promise-native";
 import * as restify from 'restify';
 
@@ -48,6 +49,9 @@ export class AutoTestRoutes implements IREST {
 
         // >SDMM HACK< This is a hack to allow current webhooks on EdX to continue to function
         server.post('/githubWebhook', AutoTestRoutes.githubWebhook); // forward GitHub Webhooks to AutoTest
+
+        server.get('/portal/at/docker/images', AutoTestRoutes.getDockerImages);
+        server.post('/portal/at/docker/image', AutoTestRoutes.postDockerImage);
     }
 
     public static handleError(code: number, msg: string, res: any, next: any) {
@@ -441,5 +445,68 @@ export class AutoTestRoutes implements IREST {
             //     }
             // });
         });
+    }
+
+    public static async getDockerImages(req: any, res: any, next: any) {
+        try {
+            const config = Config.getInstance();
+
+            const atHost = config.getProp(ConfigKey.autotestUrl);
+            const url = atHost + ':' + config.getProp(ConfigKey.autotestPort) + '/docker/images';
+            const options = {
+                uri:     url,
+                method:  'GET',
+                json:    true
+            };
+            const githubId = req.headers.user;
+            const pc = new PersonController();
+            const person = await pc.getGitHubPerson(githubId);
+            const privileges =  await new AuthController().personPriviliged(person);
+            if (privileges.isAdmin) {
+                try {
+                    const atResponse = await rp(options);
+                    res.send(200, atResponse);
+                } catch (err) {
+                    Log.error("AutoTestRoutes::getDockerImages(..) - ERROR Sending request to AutoTest service. " + err);
+                }
+            } else {
+                res.send(401);
+            }
+        } catch (err) {
+            res.send(400);
+        }
+        return next();
+    }
+
+    public static async postDockerImage(req: any, res: any, next: any) {
+        try {
+            const config = Config.getInstance();
+
+            const atHost = config.getProp(ConfigKey.autotestUrl);
+            const url = atHost + ':' + config.getProp(ConfigKey.autotestPort) + '/docker/image';
+            const options = {
+                uri:     url,
+                method:  'POST',
+                json:    true,
+                body: req.body
+            };
+            const githubId = req.headers.user;
+            const pc = new PersonController();
+            const person = await pc.getGitHubPerson(githubId);
+            const privileges =  await new AuthController().personPriviliged(person);
+            if (privileges.isAdmin) {
+                try {
+                    // Use native request library. See https://github.com/request/request-promise#api-in-detail.
+                    request(options).pipe(res);
+                } catch (err) {
+                    Log.error("AutoTestRoutes::getDockerImages(..) - ERROR Sending request to AutoTest service. " + err);
+                }
+            } else {
+                res.send(401);
+            }
+        } catch (err) {
+            res.send(400);
+        }
+        return next();
     }
 }

--- a/packages/portal/frontend/html/cs310/admin.html
+++ b/packages/portal/frontend/html/cs310/admin.html
@@ -713,7 +713,7 @@
                                 <ons-list id="docker-image-list">
                                     <ons-list-item>
                                         <label class="left">
-                                            <ons-radio name="color" input-id="radio-0" disabled style=""></ons-radio>
+                                            <ons-radio name="docker-image" input-id="radio-0" disabled style=""></ons-radio>
                                         </label>
                                         <label for="radio-0" class="center">
                                             <ons-row>
@@ -831,17 +831,17 @@
                 </div>
             </ons-modal>
 
-            <form id="build-image-form">
+            <form id="build-image-form" >
                 <ons-list>
                     <ons-list-item expandable>
                         <div class="left settingIcon">
-                            <ons-icon icon="fa-cogs"></ons-icon>
+                            <ons-icon icon="fa-github"></ons-icon>
                         </div>
                         <div class="center settingLabel">
                             GitHub URL
                         </div>
                         <div class="right settingRight">
-                            <ons-input class="settingTextInput" id="docker-image-context-input" required></ons-input>
+                            <ons-input class="settingTextInput" id="docker-image-context-input" type="url" required></ons-input>
                         </div>
                         <div class="expandable-content">
                             See <a href="https://docs.docker.com/engine/reference/commandline/build/#git-repositories">docker build</a> documentation for details about how to construct the URL.
@@ -850,16 +850,16 @@
 
                     <ons-list-item expandable>
                         <div class="left settingIcon">
-                            <ons-icon icon="fa-cogs"></ons-icon>
+                            <ons-icon icon="fa-tag"></ons-icon>
                         </div>
                         <div class="center settingLabel">
-                            Tag
+                            Version
                         </div>
                         <div class="right settingRight">
-                            <ons-input class="settingTextInput" id="docker-image-tag-input" required></ons-input>
+                            <ons-input class="settingTextInput" id="docker-image-tag-input"></ons-input>
                         </div>
                         <div class="expandable-content">
-                            Give the image a meaningful name.
+                            Optional. You can include the Git revision (commit or tag) for traceability.
                         </div>
                     </ons-list-item>
 

--- a/packages/portal/frontend/html/cs310/admin.html
+++ b/packages/portal/frontend/html/cs310/admin.html
@@ -863,6 +863,21 @@
                         </div>
                     </ons-list-item>
 
+                    <ons-list-item expandable>
+                        <div class="left settingIcon">
+                            <ons-icon icon="fa-file-alt"></ons-icon>
+                        </div>
+                        <div class="center settingLabel">
+                            Dockerfile name
+                        </div>
+                        <div class="right settingRight">
+                            <ons-input class="settingTextInput" id="docker-image-file-input"></ons-input>
+                        </div>
+                        <div class="expandable-content">
+                            Optional. Specify the name of your Dockerfile if it is different from "Dockerfile".
+                        </div>
+                    </ons-list-item>
+
                     <ons-list-item class="list-item" id="docker-image-create">
                         <div class="center list-item__center">
                             <button id="build-image-button" class="button--large button" type="submit">Build Image</button>

--- a/packages/portal/frontend/html/cs310/admin.html
+++ b/packages/portal/frontend/html/cs310/admin.html
@@ -682,6 +682,23 @@
                         </ons-list-item>
                     </ons-list>
                     <ons-list id="shouldAutoTestList" style="padding-bottom: 4.5em;">
+                        <!--<ons-list-item expandable>-->
+                            <!--<div class="left settingIcon">-->
+                                <!--<ons-icon icon="fa-cloud"></ons-icon>-->
+                            <!--</div>-->
+                            <!--<div class="center settingLabel">-->
+                                <!--Docker Image Name-->
+                            <!--</div>-->
+                            <!--<div class="right settingRight">-->
+                                <!--<ons-input class="settingTextInput" id="adminEditDeliverablePage-atDockerName"></ons-input>-->
+                            <!--</div>-->
+                            <!--<div class="expandable-content">-->
+                                <!--AutoTest Docker Image name that knows how to execute this deliverable.-->
+                                <!--It must also know how to execute any regression deliverables, if any are specified.-->
+                            <!--</div>-->
+                        <!--</ons-list-item>-->
+
+
                         <ons-list-item expandable>
                             <div class="left settingIcon">
                                 <ons-icon icon="fa-cloud"></ons-icon>
@@ -689,14 +706,38 @@
                             <div class="center settingLabel">
                                 Docker Image Name
                             </div>
-                            <div class="right settingRight">
-                                <ons-input class="settingTextInput" id="adminEditDeliverablePage-atDockerName"></ons-input>
-                            </div>
+                            <!--<div class="right settingRight expandable-content">-->
+                            <!--<ons-input class="settingTextInput" id="adminEditDeliverablePage-atDockerName" value="None:None" disabled></ons-input>-->
+                            <!--</div>-->
                             <div class="expandable-content">
-                                AutoTest Docker Image name that knows how to execute this deliverable.
-                                It must also know how to execute any regression deliverables, if any are specified.
+                                <ons-list id="docker-image-list">
+                                    <ons-list-item>
+                                        <label class="left">
+                                            <ons-radio name="color" input-id="radio-0" disabled style=""></ons-radio>
+                                        </label>
+                                        <label for="radio-0" class="center">
+                                            <ons-row>
+                                                <ons-col>SHA</ons-col>
+                                                <ons-col>Tag</ons-col>
+                                                <ons-col>Created</ons-col>
+                                            </ons-row>
+                                        </label>
+                                    </ons-list-item>
+                                </ons-list>
+
+
+                                <ons-list-item class="list-item" id="docker-image-create">
+                                    <div class="center list-item__center">
+                                        <ons-button id="btnNewImage" modifier="large" class="button--large button">Create New
+                                            Image
+                                        </ons-button>
+                                    </div>
+                                </ons-list-item>
                             </div>
                         </ons-list-item>
+
+
+
 
                         <ons-list-item expandable>
                             <div class="left settingIcon">
@@ -774,5 +815,65 @@
 
         </ons-page>
     </template>
+
+
+    <template id="createDockerImage.html">
+        <ons-page id="create-docker-image-page">
+            <div class="left">
+                <ons-back-button id="create-docker-image-back">Back</ons-back-button>
+            </div>
+
+            <ons-modal direction="up">
+                <div style="text-align: center">
+                    <p>
+                        <ons-icon icon="md-spinner" size="28px" spin></ons-icon> Building...
+                    </p>
+                </div>
+            </ons-modal>
+
+            <form id="build-image-form">
+                <ons-list>
+                    <ons-list-item expandable>
+                        <div class="left settingIcon">
+                            <ons-icon icon="fa-cogs"></ons-icon>
+                        </div>
+                        <div class="center settingLabel">
+                            GitHub URL
+                        </div>
+                        <div class="right settingRight">
+                            <ons-input class="settingTextInput" id="docker-image-context-input" required></ons-input>
+                        </div>
+                        <div class="expandable-content">
+                            See <a href="https://docs.docker.com/engine/reference/commandline/build/#git-repositories">docker build</a> documentation for details about how to construct the URL.
+                        </div>
+                    </ons-list-item>
+
+                    <ons-list-item expandable>
+                        <div class="left settingIcon">
+                            <ons-icon icon="fa-cogs"></ons-icon>
+                        </div>
+                        <div class="center settingLabel">
+                            Tag
+                        </div>
+                        <div class="right settingRight">
+                            <ons-input class="settingTextInput" id="docker-image-tag-input" required></ons-input>
+                        </div>
+                        <div class="expandable-content">
+                            Give the image a meaningful name.
+                        </div>
+                    </ons-list-item>
+
+                    <ons-list-item class="list-item" id="docker-image-create">
+                        <div class="center list-item__center">
+                            <button id="build-image-button" class="button--large button" type="submit">Build Image</button>
+                        </div>
+                    </ons-list-item>
+                </ons-list>
+            </form>
+
+            <div id="docker-image-build-output"></div>
+        </ons-page>
+    </template>
+
 
 </ons-page>

--- a/packages/portal/frontend/html/cs310/admin.html
+++ b/packages/portal/frontend/html/cs310/admin.html
@@ -844,7 +844,7 @@
                             <ons-input class="settingTextInput" id="docker-image-context-input" type="url" required></ons-input>
                         </div>
                         <div class="expandable-content">
-                            See <a href="https://docs.docker.com/engine/reference/commandline/build/#git-repositories">docker build</a> documentation for details about how to construct the URL.
+                            See <a href="https://docs.docker.com/engine/reference/commandline/build/#git-repositories">docker build</a> documentation for details about how to construct the URL. The URL should start with "https://". If the repository is public, set GH_DOCKER_TOKEN in the .env. Do not include the token in the URL.
                         </div>
                     </ons-list-item>
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -44,10 +44,10 @@ export class UI {
         }
     }
 
-    public static popPage() {
+    public static popPage(options?: any) {
         const nav = document.querySelector('#myNavigator') as any; // as ons.OnsNavigatorElement;
         if (nav !== null) {
-            nav.popPage();
+            nav.popPage(options);
         } else {
             Log.error('UI::popPage(..) - WARN: nav is null');
         }
@@ -137,12 +137,12 @@ export class UI {
     public static showError(failure: any) { // FailurePayload
         Log.error("UI::showError(..) - failure: " + JSON.stringify(failure));
         if (typeof failure === 'string') {
-            UI.showAlert(failure);
+            return UI.showAlert(failure);
         } else if (typeof failure.failure !== 'undefined') {
-            UI.showAlert(failure.failure.message);
+            return UI.showAlert(failure.failure.message);
         } else {
             Log.error("Unknown message: " + JSON.stringify(failure));
-            UI.showAlert("Action unsuccessful.");
+            return UI.showAlert("Action unsuccessful.");
         }
     }
 
@@ -261,7 +261,7 @@ export class UI {
     }
 
     public static showAlert(message: string) {
-        ons.notification.alert(message);
+        return ons.notification.alert(message);
     }
 
     // SDMM: move

--- a/packages/portal/frontend/src/app/views/AdminConfigTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminConfigTab.ts
@@ -36,6 +36,19 @@ export class AdminConfigTab extends AdminPage {
 
         await this.deliverablesPage.init(opts);
 
+        const images = await this.getImageList();
+        that.bindImagesToTable(images, document.querySelector("#docker-image-list"));
+
+        (document.querySelector('#btnNewImage') as OnsButtonElement).onclick = function(evt) {
+            const nav = document.querySelector('#dockerConfigManager');
+            nav.pushPage('createDockerImage.html');
+            nav.addEventListener("postpop", function(event) {
+                const sha = document.querySelector('#dockerConfigManager').topPage.data.sha;
+                getImageList(sha);
+
+            });
+        };
+
         (document.querySelector('#adminSubmitClasslist') as OnsButtonElement).onclick = function(evt) {
             Log.info('AdminConfigTab::handleAdminConfig(..) - upload classlist pressed');
             evt.stopPropagation(); // prevents list item expansion
@@ -160,6 +173,35 @@ export class AdminConfigTab extends AdminPage {
             }).catch(function(err) {
                 Log.info('AdminConfigTab::handleAdminConfig(..) - perform withdraw pressed; ERROR: ' + err.message);
             });
+        };
+
+        (document.querySelector("#build-image-form") as OnsButtonElement).onclick = function(evt) {
+            const modal = document.querySelector('ons-modal');
+            const contextInput = document.querySelector("#docker-image-context-input");
+            const tagInput = document.querySelector("#docker-image-tag-input");
+            const submit = document.querySelector("#build-image-button");
+            const outputArea = document.querySelector("#docker-image-build-output");
+
+            const context = contextInput.value;
+            const tag = tagInput.value;
+
+            contextInput.disabled = true;
+            tagInput.disabled = true;
+            submit.disabled = true;
+
+            modal.show();
+
+            that.buildImage(context, tag, outputArea).then(function(sha) {
+                document.querySelector("#create-docker-image-back").options = {data: {sha}};
+                modal.hide();
+            }).catch(function(err) {
+                // ons.notification.alert(err);
+                contextInput.disabled = false;
+                tagInput.disabled = false;
+                submit.disabled = false;
+                modal.hide();
+            });
+            return false;
         };
 
         UI.showModal("Retriving config / deliverable details.");
@@ -500,4 +542,86 @@ export class AdminConfigTab extends AdminPage {
         Log.trace('AdminConfigTab::releaseDeliverablePressed(..) - done; took: ' + UI.took(start));
     }
 
+    private async buildImage(context: string, tag: string, output: Element): Promise<string> {
+        return new Promise<string>(function(resolve, reject) {
+            let lines: string[] = [];
+            let lastIndex = 0;
+            const httpRequest = new XMLHttpRequest();
+            httpRequest.onprogress = function() {
+                const currIndex = httpRequest.responseText.length;
+                if (lastIndex === currIndex) {
+                    return;
+                }
+                const chunk = httpRequest.responseText.substring(lastIndex, currIndex);
+                lastIndex = currIndex;
+
+                const chunkLines = chunk.split("\n").filter((s) => s !== "").map((s) => JSON.parse(s).stream.trim());
+                output.innerText += chunkLines.join("\n");
+                lines = lines.concat(chunkLines);
+            };
+            httpRequest.onreadystatechange = function() {
+                if (httpRequest.readyState === XMLHttpRequest.DONE) {
+                    if (httpRequest.status === 200) {
+                        const sha = lines[lines.length - 2].replace("Successfully built ", "");
+                        // const tag = lines[lines.length - 1].replace("Successfully tagged ", "");
+                        resolve(sha);
+                    } else {
+                        reject('There was a problem with the request: ' + httpRequest.status);
+                    }
+                }
+            };
+            httpRequest.open('POST', '/image');
+            httpRequest.send(JSON.stringify({remote: context, tag: tag}));
+        });
+    }
+
+    private async getImageList(): Promise<any[]> {
+        return new Promise(function(resolve, reject) {
+            const httpRequest = new XMLHttpRequest();
+            httpRequest.onreadystatechange = function() {
+                if (httpRequest.readyState === XMLHttpRequest.DONE) {
+                    if (httpRequest.status === 200) {
+                        let images: any[];
+                        try {
+                            images = JSON.parse(httpRequest.responseText);
+                            resolve(images);
+                        } catch (err) {
+                            reject(err);
+                        }
+                    } else {
+                        reject('There was a problem with the request: ' + httpRequest.status);
+                    }
+                }
+            };
+            httpRequest.open('GET', '/portal/admin/images');
+            httpRequest.send();
+        });
+    }
+
+    private bindImagesToTable(images: any[], table: Element, selected?: string): void {
+        const frag = document.createDocumentFragment();
+        let idxId = 1;
+        for (const image of images) {
+            const id = image.Id.substring(7, 19); // Strip off "sha256:" and show first 12 characters
+            const tag = image.RepoTags[image.RepoTags.length - 1]; // Only use the last assigned tag
+            const created = new Date(image.Created * 1000); // Convert the Unix timestamp in seconds to milliseconds
+            const e = document.createRange().createContextualFragment(`
+                <ons-list-item tappable>
+                    <label class="left">
+                        <ons-radio name="color" input-id="radio-${idxId}" ${selected === id ? "checked" : ""}></ons-radio>
+                    </label>
+                    <label for="radio-${idxId}" class="center">
+                        <ons-row>
+                            <ons-col>${id}</ons-col>
+                            <ons-col>${tag}</ons-col>
+                            <ons-col>${created}</ons-col>
+                        </ons-row>
+                    </label>
+                </ons-list-item>
+                `);
+            frag.appendChild(e);
+            idxId++;
+        }
+        table.insertBefore(frag, table.lastChild);
+    }
 }

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -608,8 +608,15 @@ export class AdminDeliverablesTab extends AdminPage {
         let idxId = 1;
         for (const image of images) {
             const id = image.Id.substring(7, 19); // Strip off "sha256:" and show first 12 characters
-            const tag = image.RepoTags; // [image.RepoTags.length - 1]; // Only use the last assigned tag
+            const tag = image.RepoTags[0]; // Only use the first tag (they are sorted alphabetically)
             const created = new Date(image.Created * 1000); // Convert the Unix timestamp in seconds to milliseconds
+
+            // NOTE: Assuming that there is only a "grader"
+            if (!tag.startsWith("grader")) {
+                // Only show grading containers in the output
+                continue;
+            }
+
             const e = document.createRange().createContextualFragment(`
                 <ons-list-item tappable>
                     <label class="left">

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -557,7 +557,7 @@ export class AdminDeliverablesTab extends AdminPage {
                         }
                     }
                 };
-                xhr.open('POST', remote + '/portal/admin/image');
+                xhr.open('POST', remote + '/portal/at/docker/image');
                 for (const [header, value] of Object.entries(headers)) {
                     xhr.setRequestHeader(header, value);
                 }
@@ -572,7 +572,7 @@ export class AdminDeliverablesTab extends AdminPage {
         Log.info("AdminDeliverablesTab::getDockerImages( .. ) - start");
         const start = Date.now();
         const options = AdminView.getOptions();
-        const url = this.remote + '/portal/admin/images';
+        const url = this.remote + '/portal/at/docker/images';
         const response = await fetch(url, options);
 
         if (response.status === 200) {

--- a/packages/portal/frontend/src/app/views/DockerListImageView.ts
+++ b/packages/portal/frontend/src/app/views/DockerListImageView.ts
@@ -1,0 +1,120 @@
+import {OnsListItemElement, OnsRadioElement} from "onsenui";
+import Log from "../../../../../common/Log";
+import {UI} from "../util/UI";
+
+export interface DockerImage {
+    id: string;
+    tag: string;
+    created: Date;
+}
+
+export class DockerListImageView {
+    public readonly list: any;
+
+    constructor(list: any) {
+        this.list = list;
+    }
+
+    public async bind(dataSource: any, state: any) {
+        try {
+            const data = await this.getDockerImages(dataSource.url, dataSource.options);
+            const dockerImages: DockerImage[] = data.map((d) => {
+                return {
+                    id: d.Id.substring(7, 19), // Strip off "sha256:" and show first 12 characters
+                    tag: d.RepoTags[0], // Only use the first tag (they are sorted alphabetically)
+                    created: new Date(d.Created * 1000) // Convert the Unix timestamp in seconds to milliseconds
+                };
+            });
+            const pendingAdditionsFragment = document.createDocumentFragment();
+            const listItems = this.list.querySelectorAll("ons-list-item:not(:first-child)");
+
+            for (const image of dockerImages) {
+                let exists = false;
+                for (const item of listItems) {
+                    const id = item.querySelector("label[for] > ons-row > ons-col").innerText;
+                    if (image.id.startsWith(id)) {
+                        exists = true;
+                        if (id === state.checkedItemId) {
+                            this.setCheckedItem(item);
+                        }
+                        break;
+                    }
+                }
+                if (!exists) {
+                    const item = DockerListImageView.generateListItem(image, image.id.startsWith(state.checkedItemId));
+                    pendingAdditionsFragment.appendChild(item);
+                }
+            }
+
+            for (const item of listItems) {
+                let exists = false;
+                for (const image of dockerImages) {
+                    const id = item.querySelector("label[for] > ons-row > ons-col").innerText;
+                    if (image.id.startsWith(id)) {
+                        exists = true;
+                        break;
+                    }
+                }
+                if (!exists) {
+                    this.removeListItem(item);
+                }
+            }
+
+            this.addListItems(pendingAdditionsFragment);
+        } catch (err) {
+            Log.error("DockerListImageView::bind() - ERROR Binding data to list. " + err);
+        }
+    }
+
+    public addListItems(items: DocumentFragment) {
+        this.list.appendChild(items);
+    }
+
+    public removeListItem(item: OnsListItemElement) {
+        this.list.removeChild(item);
+    }
+
+    public setCheckedItem(item: OnsListItemElement) {
+        const radio: OnsRadioElement = item.querySelector('ons-radio');
+        radio.checked = true;
+    }
+
+    public static generateListItem(image: DockerImage, checked: boolean): DocumentFragment {
+
+        return document.createRange().createContextualFragment(`
+                <ons-list-item tappable>
+                    <label class="left">
+                        <ons-radio name="docker-image" input-id="radio-${image.id}" ${checked ? "checked" : ""}></ons-radio>
+                    </label>
+                    <label for="radio-${image.id}" class="center">
+                        <ons-row>
+                            <ons-col>${image.id}</ons-col>
+                            <ons-col>${image.tag}</ons-col>
+                            <ons-col>${image.created}</ons-col>
+                        </ons-row>
+                    </label>
+                </ons-list-item>
+                `);
+    }
+
+    private async getDockerImages(url: string, options: any): Promise<any[]> {
+        Log.info("DockerListImageView::getDockerImages( .. ) - start");
+        const start = Date.now();
+        const response = await fetch(url, options);
+
+        if (response.status === 200) {
+            Log.trace('DockerListImageView::getDockerImages(..) - 200 received');
+            const json = await response.json();
+            if (Array.isArray(json)) {
+                Log.trace('DockerListImageView::getDockerImages(..)  - worked; took: ' + UI.took(start));
+                return json;
+            } else {
+                Log.trace('DockerListImageView::getDockerImages(..)  - ERROR Expected array; got ' + json);
+                throw new Error('Invalid response body format');
+            }
+        } else {
+            Log.trace('DockerListImageView::getDockerImages(..)  - !200 received: ' + response.status);
+            throw await response.text();
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,6 +210,16 @@
     "@types/node" "*"
     "@types/tough-cookie" "*"
 
+"@types/request@2.48.1":
+  version "2.48.1"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.48.1.tgz#e402d691aa6670fbbff1957b15f1270230ab42fa"
+  integrity sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==
+  dependencies:
+    "@types/caseless" "*"
+    "@types/form-data" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+
 "@types/restify@^5.0.7":
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/@types/restify/-/restify-5.0.7.tgz#09b736ad96af04814f9501b7b50e84dabcd77228"


### PR DESCRIPTION
- To limit how many containers need access to the Docker daemon, requests for getting the list of Docker images and posting new images are authorized through portal backend (allowing only admins) and then forwarded to autotest for processing.
- The list of images displayed are limited to those built using the UI (specifically, those with the tag `grader`). However, the client only requests a filtered list; it is still possible to request a list of all images.
- Currently, the UI will only display a single tag (the first one alphabetically). If users repeatedly build the exact same image but specify different versions, it may not be obvious in the list. (Not sure why this would come up other than accidentally).
- The tag name for the image in no longer used to create a grading container; instead, the image sha is used.
- More testing is needed.