### PR TITLE
Update deploy docs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -148,7 +148,7 @@ AUTOTEST_POSTBACK=false
 
 ## Where the AutoTest service should store persistent data (e.g. grade container execution logs)
 ## This path is on the HOST machine (and is the mount point for PERSIST_DIR inside the grade container)
-HOST_DIR=./data/runs
+HOST_DIR=/var/opt/classy/runs
 
 ## Where the AutoTest service should store persistent data (e.g. grade container execution logs)
 ## This path is INSIDE the container (and is bound to HOST_DIR on the host machine)
@@ -159,21 +159,9 @@ PERSIST_DIR=/DEVPATH/classy/packages/autotest/test/data
 ## and the grading container.
 UID=993
 
-## [SDMM/310 Only] Port that the geo-location service should listen on
-## MUST BE SET TO 11316 (this is baked into the service's dockerfile)
-GEO_PORT=11316
-
-## [SDMM/310 Only] Port that the reference UI service should listen on.
-## MUST BE SET TO 11315 (this is baked into the service's dockerfile)
-UI_PORT=11315
-
-
 #####
 ##### Deployment Only
 #####
-
-# The Docker daemon socket. Specify a value here if not using the default unix:///var/run/docker.sock.
-DOCKER_HOST_URL=tcp://$hostname:2376
 
 ## The name docker-compose will prefix to every container
 COMPOSE_PROJECT_NAME=classy
@@ -192,8 +180,3 @@ GH_DOCKER_TOKEN=asb865...
 ## This is required since the grading container will not be able to make DNS requests.
 ## Format hostname:IP
 HOSTS_ALLOW=classy.cs.ubc.ca:142.103.6.191
-
-## Specifies the mode under which the reference implementation should operate.
-## Currently supports values 'd1' and 'd2'.
-## Affects the reference UI and the grading container.
-PLATFORM=d1

--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,7 @@
 ##### automatically invalidate them and your course _will_ break.
 #####
 
+
 #####
 #####
 ##### Core Settings
@@ -20,36 +21,9 @@ NAME=cs310
 ## created inside it.
 ORG=CS310-2017Jan
 
-## GitHub org identifier for the test organization (you probably do not want to change this)
-ORGTEST=classytest
-
-## Course name for the test instance (you probably do not want to change this)
-NAMETEST=classytest
-
 ## The external name used for the Classy service (used by GitHub WebHooks)
 ## Must start with https:// and should not have a trailing slash
 PUBLICHOSTNAME=https://classy.cs.ubc.ca
-
-## Set the logging verbosity: TRACE (default), INFO, WARN, ERROR, TEST, NONE
-LOG_LEVEL=INFO
-
-#####
-#####
-##### Host config for portal/backend; no trailing slash
-##### https://localhost is usually used for testing
-#####
-#####
-
-
-## URL (no trailing slash) for Classy backend; different than HOSTNAME as this is the
-## internal name (e.g., as Classy is addressed to other local services)
-BACKEND_URL=https://localhost
-BACKEND_PORT=3000
-
-## Full path to fullchain.pem (Can be self-signed for localhost testing)
-SSL_CERT_PATH=/DEVPATH/classy/packages/portal/backend/ssl/fullchain.pem
-## Full path to privkey.pem (Can be self-signed for localhost testing)
-SSL_KEY_PATH=/DEVPATH/classy/packages/portal/backend/ssl/privkey.pem
 
 
 #####
@@ -58,27 +32,47 @@ SSL_KEY_PATH=/DEVPATH/classy/packages/portal/backend/ssl/privkey.pem
 #####
 #####
 
-## For testing, you can spin up a basic mongo instance (w/o authentication) using:
-## `docker run -p 27017:27017 mongo`
-## Specify the DB_URL as below to connect:
-# DB_URL=mongodb://localhost:27017
-
-
 ## To spin up a mongo instance with authentication, specify a username and password below.
 ## Notes:
 ## - you must specify the username and password twice (once for the MONGO_INITDB_ROOT_* and once in the DB_URL)
 ## - the username/password will only be applied on the **FIRST** launch of the db service (otherwise they have no effect)
-## - when deploying with Docker Compose, replace _localhost_ with the value of CONTAINER_NAME_DATABASE (set below).
+## - when deploying with Docker Compose, replace `localhost` with `db`.
 ## - the DB_URL must be URI encoded if it contains special characters
+## For local testing, you can spin up a basic mongo instance (w/o authentication) using: `docker run -p 27017:27017 mongo`
+## and setting DB_URL=mongodb://localhost:27017
 MONGO_INITDB_ROOT_USERNAME=mongoadmin
 MONGO_INITDB_ROOT_PASSWORD=strongpasswd
 DB_URL=mongodb://mongoadmin:strongpasswd@localhost:27017/?authMechanism=DEFAULT
+
 
 #####
 #####
 ##### GitHub Configuration
 #####
 #####
+
+## A GitHub token so the bot can use the GitHub API without going
+## through authentication. It is important that this token be well
+## protected as without it you can lose programmatic access to student
+## projects. The format should be:
+## GH_BOT_TOKEN=token d4951x....
+## (yes the word token is required)
+## If you want to use ubcbot, contact Reid Holmes for a token.
+GH_BOT_TOKEN=token d4951x...
+
+## Before you can authenticate against GitHub you will need to create
+## two OAuth applications on the org; e.g., for public GitHub you can
+## do this here: https://github.com/organizations/ORGNAME/settings/applications
+##
+## For Testing, create one with an Authorization callback URL similar to:
+## https://localhost:3000/authCallback?orgName=ORGNAME
+## For Production, create another with your production backend host:
+## e.g., https://sdmm.cs.ubc.ca/authCallback?orgName=ORGNAME
+##
+## The Client ID and Client Secret for the OAuth profile (testing or prod)
+## you intend to use should be included below. These _must_ be protected.
+GH_CLIENT_ID=f42b49hut...
+GH_CLIENT_SECRET=1337secretTokenCharsHere...
 
 ## GitHub API host (no trailing slash). This is because the API host is often different than the web host.
 ## For public github it will be: https://api.github.com
@@ -97,44 +91,33 @@ GH_HOST=https://github.com
 ## e.g., for public GitHub here: https://github.com/orgs/ORGNAME/people
 GH_BOT_USERNAME=ubcbot
 
-## A GitHub token so the bot can use the GitHub API without going
-## through authentication. It is important that this token be well
-## protected as without it you can lose programmatic access to student
-## projects. The format should be:
-## GH_BOT_TOKEN=token d4951x....
-## (yes the word token is required)
-## If you want to use ubcbot, contact Reid Holmes for a token.
 
-GH_BOT_TOKEN=token d4951x...
-
-
-## Before you can authenticate against GitHub you will need to create
-## two OAuth applications on the org; e.g., for public GitHub you can
-## do this here: https://github.com/organizations/ORGNAME/settings/applications
-##
-## For Testing, create one with an Authorization callback URL similar to:
-## https://localhost:3000/authCallback?orgName=ORGNAME
-## For Production, create another with your production backend host:
-## e.g., https://sdmm.cs.ubc.ca/authCallback?orgName=ORGNAME
-##
-## The Client ID and Client Secret for the OAuth profile (testing or prod)
-## you intend to use should be included below. These _must_ be protected.
-
-GH_CLIENT_ID=f42b49hut...
-GH_CLIENT_SECRET=1337secretTokenCharsHere...
-
-
-#####
 #####
 #####
 ##### AutoTest Settings
 #####
 #####
-#####
+
+## The uid for the (non-root) user that should run the containers (if following deploy instructions, should be the uid
+## for the classy user). Also used by the AutoTest service to configure permissions on directories shared between autotest
+## and the grading container.
+UID=993
+
+## The group id for the docker group on the host. Use `cut -d: -f3 < <(getent group docker)` to get the id.
+## Used by containers that need to access the docker socket.
+GID=989
+
+## GitHub token with permission to clone the repository containing the Dockerfile for the grading container
+GH_DOCKER_TOKEN=asb865...
+
+## Include a hostname to IP address mapping for outgoing requests from grading containers.
+## This mapping is required since the grading container will not be able to make DNS requests.
+## Format hostname:IP
+HOSTS_ALLOW=classy.cs.ubc.ca:142.103.6.191
 
 ## When using docker-compose, an entry is added to the hosts file for each
 ## dependent service. Thus, we just need to specify the service name in the URL.
-AUTOTEST_URL=http://localhost
+AUTOTEST_URL=http://autotest
 
 ## AutoTest instance port.
 AUTOTEST_PORT=11333
@@ -152,35 +135,45 @@ HOST_DIR=/var/opt/classy/runs
 
 ## Where the AutoTest service should store persistent data (e.g. grade container execution logs)
 ## This path is INSIDE the container (and is bound to HOST_DIR on the host machine)
-PERSIST_DIR=/DEVPATH/classy/packages/autotest/test/data
+PERSIST_DIR=/output
 
-## The uid for the (non-root) user that should run the containers (if following deploy instructions, should be the uid
-## for the classy user). Also used by the AutoTest service to configure permissions on directories shared between autotest
-## and the grading container.
-UID=993
-
-## The group id for the docker group on the host. Use `cut -d: -f3 < <(getent group docker)` to get the id.
-## Used by containers that need to access the docker socket.
-GID=989
 
 #####
-##### Deployment Only
 #####
+##### Portal Settings
+#####
+#####
+
+## URL (no trailing slash) for Classy backend; different than HOSTNAME as this is the
+## internal name (e.g., as Classy is addressed to other local services)
+## https://localhost is usually used for testing
+BACKEND_URL=https://portal
+BACKEND_PORT=3000
+
+
+#####
+#####
+##### Miscellaneous Settings
+#####
+#####
+
+## Full path to fullchain.pem (Can be self-signed for localhost testing)
+SSL_CERT_PATH=/etc/ssl/fullchain.pem
+## Full path to privkey.pem (Can be self-signed for localhost testing)
+SSL_KEY_PATH=/etc/ssl/privkey.pem
+
+## The location of the SSL certificate and private key on the host (if deployed)
+HOST_SSL_CERT_PATH=/opt/classy/ssl/fullchain.pem
+HOST_SSL_KEY_PATH=/opt/classy/ssl/privkey.pem
 
 ## The name docker-compose will prefix to every container
 COMPOSE_PROJECT_NAME=classy
 
-## The location of the SSL certificate and private key.
-HOST_SSL_CERT_PATH=/opt/classy/ssl/fullchain.pem
-HOST_SSL_KEY_PATH=/opt/classy/ssl/privkey.pem
+## GitHub org identifier for the test organization (you probably do not want to change this)
+ORGTEST=classytest
 
-## GitHub token with read access to clone repositories in the org for the particular course offering
-COURSE_GH_ORG_TOKEN=asb865...
+## Course name for the test instance (you probably do not want to change this)
+NAMETEST=classytest
 
-## GitHub token with permission to clone the repository containing the Dockerfile for the grading container
-GH_DOCKER_TOKEN=asb865...
-
-## [310/SDMM Only] A single hosts entry used to resolve the hostname of the server running geolocation.
-## This is required since the grading container will not be able to make DNS requests.
-## Format hostname:IP
-HOSTS_ALLOW=classy.cs.ubc.ca:142.103.6.191
+## Set the logging verbosity: TRACE (default), INFO, WARN, ERROR, TEST, NONE
+LOG_LEVEL=INFO

--- a/.env.sample
+++ b/.env.sample
@@ -159,6 +159,10 @@ PERSIST_DIR=/DEVPATH/classy/packages/autotest/test/data
 ## and the grading container.
 UID=993
 
+## The group id for the docker group on the host. Use `cut -d: -f3 < <(getent group docker)` to get the id.
+## Used by containers that need to access the docker socket.
+GID=989
+
 #####
 ##### Deployment Only
 #####

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@
 # - Services specified here can be extended (and additional services can be added) by creating additional
 #   docker-compose.yml files. See https://docs.docker.com/compose/extends/#example-use-case.
 
-# NOTE: Do not change the service names. They are used to refer to the service throughout the codebase in http requests.
+# NOTE: Do not change the container names. They are used to refer to the service throughout the codebase in http requests.
 
 version: "3.5"
 
@@ -25,19 +25,20 @@ services:
         build:
             context: ./
             dockerfile: ./packages/autotest/Dockerfile
+        container_name: autotest
         depends_on:
             - db
         env_file: .env
         expose:
             - ${AUTOTEST_PORT}
         restart: always
-        user: "${UID}"
+        user: "${UID}:${cut -d: -f3 < <(getent group docker)}"
         volumes:
             - "${HOST_DIR}:${PERSIST_DIR}"
-            - "${HOST_SSL_CERT_PATH}:${SSL_CERT_PATH}"
-            - "${HOST_SSL_KEY_PATH}:${SSL_KEY_PATH}"
+            - "/var/run/docker.sock:/var/run/docker.sock"
     db:
         command: --quiet
+        container_name: db
         environment:
           - MONGO_INITDB_ROOT_USERNAME
           - MONGO_INITDB_ROOT_PASSWORD
@@ -55,15 +56,13 @@ services:
                 - GH_BOT_EMAIL
             context: ./
             dockerfile: ./packages/portal/Dockerfile
+        container_name: portal
         depends_on:
             - db
             - autotest
         env_file: .env
         expose:
             - ${BACKEND_PORT}
-        # Hack for SDMM since the github webhook hits the port directly
-        ports:
-            - 5000:${BACKEND_PORT}
         restart: always
         user: "${UID}"
         volumes:
@@ -78,6 +77,7 @@ services:
                 - BACKEND_PORT
             context: ./
             dockerfile: ./packages/proxy/Dockerfile
+        container_name: proxy
         depends_on:
             - portal
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         expose:
             - ${AUTOTEST_PORT}
         restart: always
-        user: "${UID}:${cut -d: -f3 < <(getent group docker)}"
+        user: "${UID}:${GID}"
         volumes:
             - "${HOST_DIR}:${PERSIST_DIR}"
             - "/var/run/docker.sock:/var/run/docker.sock"

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -1,7 +1,6 @@
 import * as Docker from "dockerode";
 import * as fs from "fs-extra";
 import * as restify from "restify";
-import {URL} from "url";
 import Config, {ConfigKey} from "../../../common/Config";
 import Log from "../../../common/Log";
 import {CommitTarget} from "../../../common/types/ContainerTypes";
@@ -23,21 +22,8 @@ export default class RouteHandler {
                 // Running tests; don't need to connect to the Docker daemon
                 this.docker = null;
             } else {
-                const dockerHost = Config.getInstance().getProp(ConfigKey.dockerHost) || "";
-                if (dockerHost.startsWith("https") || dockerHost.startsWith("http") || dockerHost.startsWith("tcp")) {
-                    const dockerUrl = new URL(dockerHost);
-                    RouteHandler.docker = new Docker({
-                        host: dockerUrl.hostname,
-                        port: dockerUrl.port,
-                        ca: fs.readFileSync("/etc/ssl/certs/ca-certificates.crt"),
-                        cert: fs.readFileSync(Config.getInstance().getProp(ConfigKey.sslCertPath)),
-                        key: fs.readFileSync(Config.getInstance().getProp(ConfigKey.sslKeyPath)),
-                        version: "v1.30"
-                    });
-                } else {
-                    Log.info("RouteHandler::getDocker() - Defaulting to Docker socket.");
-                    RouteHandler.docker = new Docker();
-                }
+                // Connect to the Docker socket using defaults
+                RouteHandler.docker = new Docker();
             }
         }
 

--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -54,7 +54,6 @@ export enum ConfigKey {
     hostDir = "hostDir",
     dockerUid = "dockerUid",
     hostsAllow = "hostsAllow",
-    dockerHost = "dockerHost",
     timeout = "timeout",
     botName = "botName",
     postback = "postback",
@@ -90,7 +89,6 @@ export default class Config {
                 persistDir: process.env.PERSIST_DIR,
                 dockerUid: process.env.UID,
                 hostsAllow: process.env.HOSTS_ALLOW,
-                dockerHost: process.env.DOCKER_HOST_URL,
 
                 timeout: Number(process.env.GRADER_TIMEOUT),
                 botName: process.env.GH_BOT_USERNAME,


### PR DESCRIPTION
- Pass Docker socket through directly to AutoTest service container but run container with the docker group (this gives it permissions to invoke the Docker daemon on the host machine).
- Make corrections to the deploy docs based on Michael Sanders' feedback
- Remove Docker daemon TCP configuration section as it no longer applies
- A little bit of housekeeping of .env.sample ahead of forking  