### PR TITLE
Treat HOST_DIR as root data dir

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -131,7 +131,7 @@ AUTOTEST_POSTBACK=false
 
 ## Where the AutoTest service should store persistent data (e.g. grade container execution logs)
 ## This path is on the HOST machine (and is the mount point for PERSIST_DIR inside the grade container)
-HOST_DIR=/var/opt/classy/runs
+HOST_DIR=/var/opt/classy
 
 ## Where the AutoTest service should store persistent data (e.g. grade container execution logs)
 ## This path is INSIDE the container (and is bound to HOST_DIR on the host machine)

--- a/packages/autotest/src/autotest/GradingJob.ts
+++ b/packages/autotest/src/autotest/GradingJob.ts
@@ -16,7 +16,7 @@ export class GradingJob {
     constructor(containerInput: ContainerInput) {
         this.input = containerInput;
         this.id = this.input.target.commitSHA + "-" + this.input.target.delivId;
-        this.path = Config.getInstance().getProp(ConfigKey.persistDir) + "/" + this.id;
+        this.path = Config.getInstance().getProp(ConfigKey.persistDir) + "/runs/" + this.id;
         this.record = {
             delivId: this.input.delivId,
             repoId: this.input.target.repoId,
@@ -73,7 +73,7 @@ export class GradingJob {
     }
 
     public async run(docker: Docker): Promise<AutoTestResult> {
-        const hostDir = Config.getInstance().getProp(ConfigKey.hostDir) + "/" + this.id;
+        const hostDir = Config.getInstance().getProp(ConfigKey.hostDir) + "/runs/" + this.id;
         const container = await docker.createContainer({
             User: Config.getInstance().getProp(ConfigKey.dockerUid),
             Image: this.input.containerConfig.dockerImage,

--- a/packages/autotest/src/autotest/Queue.ts
+++ b/packages/autotest/src/autotest/Queue.ts
@@ -18,9 +18,9 @@ export class Queue {
         this.numSlots = numSlots;
 
         // almost certainly exists (contains all queue output), but quick to check
-        fs.ensureDirSync(Config.getInstance().getProp(ConfigKey.persistDir));
+        fs.mkdirpSync(Config.getInstance().getProp(ConfigKey.persistDir) + '/queues');
 
-        this.persistDir = Config.getInstance().getProp(ConfigKey.persistDir) + '/' + this.name + '.json';
+        this.persistDir = Config.getInstance().getProp(ConfigKey.persistDir) + '/queues/' + this.name + '.json';
     }
 
     private data: ContainerInput[] = [];


### PR DESCRIPTION
Closes #206.

**Before deploying:** HOST_DIR in the `.env` should be changed from `HOST_DIR=/var/opt/classy/runs` to `HOST_DIR=/var/opt/classy`