### PR TITLE
Fix naming typo in Admin HTML

### DIFF
--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -1062,7 +1062,7 @@
     </template>
 
     <template id="adminProvision.html">
-        <ons-page id="adminProision">
+        <ons-page id="adminProvision">
             <ons-toolbar>
                 <div class="left">
                     <ons-back-button></ons-back-button>


### PR DESCRIPTION
(cherry picked from commit 264b9767d2f995e42d0b8f0eeb887eb8198e7501)