### PR TITLE
Fix Repositories not being planned when a deliverable's maxTeamSize is > 1

### DIFF
--- a/packages/portal/backend/src/controllers/AdminController.ts
+++ b/packages/portal/backend/src/controllers/AdminController.ts
@@ -624,9 +624,10 @@ export class AdminController {
 
         const allTeams: Team[] = await this.tc.getAllTeams();
 
-        if (deliv.teamMaxSize === 1) {
+        if (deliv.teamMaxSize === 1 || deliv.teamMinSize === 1) {
             formSingleTeams = true;
-            Log.info("AdminController::planProvision( .. ) - team maxSize 1: formSingleTeams forced to true");
+            Log.info(`AdminController::planProvision( .. ) - team minSize: ${deliv.teamMinSize}; ` +
+                `team maxSize: ${deliv.teamMaxSize}; formSingleTeams forced to true`);
         }
 
         const delivTeams: Team[] = [];


### PR DESCRIPTION
Addresses the issue where Repositories won't be provisioned when `maxTeamSize > 1`

Currently, due to `AdminRoutes` and the `AdminProvision` page always calling `AdminController.planProvision` with `formSingle = false`, students are unable to get repositories when the `maxTeamSize` is larger than 1, even when the `minTeamSize` is 1.

This patch fixes this issue, and allows repositories to be created when the `minTeamSize === 1` (which should be intended).

(cherry picked from commit 3c49ad72ce3f61f49464c59a695336e28a0b8fe4)