### PR TITLE
Set MIN_DELAY to 15 minutes instead of 1 hour.

### DIFF
--- a/packages/portal/backend/src/controllers/DeliverablesController.ts
+++ b/packages/portal/backend/src/controllers/DeliverablesController.ts
@@ -41,7 +41,7 @@ export class DeliverablesController {
         // }
 
         // the above was pretty complicated
-        const MIN_DELAY = 60 * 60; // 1 hour
+        const MIN_DELAY = 60 * 15; // 15 minutes
         if (deliv.autotest.studentDelay < MIN_DELAY) {
             deliv.autotest.studentDelay = MIN_DELAY;
         }


### PR DESCRIPTION
1 hour is too long for use in lab. 15 minutes is a good compromise?