### PR TITLE
Remove prod pinning Log.Level to INFO

### DIFF
--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -131,14 +131,6 @@ export default class Config {
                 Log.info("Config - Log::<init> - CI NOT detected");
             }
 
-            const hostname = this.config.publichostname;
-            if (hostname.indexOf("://localhost") < 0) {
-                Log.info("Config - Log::<init> - Prod detected; changing to INFO");
-                Log.Level = LogLevel.INFO;
-            } else {
-                Log.info("Config - Log::<init> - Prod NOT detected");
-            }
-
         } catch (err) {
             Log.error("Config::<init> - fatal error reading configuration file: " + err);
         }


### PR DESCRIPTION
Don't pin Log.Level to INFO when not localhost.
Trust the administrator to do the right thing...