### PR TITLE
Fix webpack error

### DIFF
--- a/packages/common/Command.ts
+++ b/packages/common/Command.ts
@@ -1,4 +1,5 @@
 import {ChildProcess, spawn, SpawnOptions} from "child_process";
+import Config from "./Config";
 import Log from "./Log";
 
 export type CommandResult = [number, any];
@@ -18,7 +19,7 @@ export class Command implements ICommand {
     }
 
     public async executeCommand(args: string[], options: SpawnOptions = {}): Promise<CommandResult> {
-        Log.trace(Log.sanitize(`Command::executeCommand(..) -> ${this.cmdName} ${args.join(" ")}`));
+        Log.trace(Config.sanitize(`Command::executeCommand(..) -> ${this.cmdName} ${args.join(" ")}`));
         return new Promise<CommandResult>((resolve, reject) => {
             let output: Buffer = Buffer.allocUnsafe(0);
             const cmd: ChildProcess = this.spawn(this.cmdName, args, options);
@@ -36,8 +37,8 @@ export class Command implements ICommand {
                 if (code === 0) {
                     resolve([code, out]);
                 } else {
-                    Log.warn(Log.sanitize(`Command::executeCommand(..) -> EXIT ${code}: ${this.cmdName} ${args.join(" ")}. ${out}`));
-                    reject([code, Log.sanitize(out)]);
+                    Log.warn(Config.sanitize(`Command::executeCommand(..) -> EXIT ${code}: ${this.cmdName} ${args.join(" ")}. ${out}`));
+                    reject([code, Config.sanitize(out)]);
                 }
             });
         });

--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -167,4 +167,22 @@ export default class Config {
         Log.warn("Config::setProp( " + ConfigKey[prop] + ", " + val + " )");
         this.config[prop] = val;
     }
+
+    /**
+     * WARNING: Can only be used by back-end, as dotenv uses FS, which does not work on front-end.
+     * Removes sensitive information from string types
+     * @param input a string that you MAY want to remove sensitive information from
+     */
+    public static sanitize(input: string): string {
+        const sensitiveKeys: ConfigKey[] = [ConfigKey.githubBotToken]; // Can add any sensitive keys here
+        const config = Config.getInstance();
+        sensitiveKeys.forEach((sk) => {
+            // HACK: replace() - edge case regarding token prefix in the config.
+            const value: string = config.getProp(sk).replace('token ', '');
+
+            const hint = value.substring(0, 4);
+            input = input.replace(new RegExp(value, 'g'), hint + '-xxxxxx');
+        });
+        return input;
+    }
 }

--- a/packages/common/Log.ts
+++ b/packages/common/Log.ts
@@ -80,21 +80,4 @@ export default class Log {
             console.log(`<X> ${new Date().toLocaleString()}: ${msg}`);
         }
     }
-
-    /**
-     * Removes sensitive information from string types
-     * @param input a string that you MAY want to remove sensitive information from
-     */
-    public static sanitize(input: string): string {
-        const sensitiveKeys: ConfigKey[] = [ConfigKey.githubBotToken]; // Can add any sensitive keys here
-        const config = Config.getInstance();
-        sensitiveKeys.forEach((sk) => {
-            // HACK: replace() - edge case regarding token prefix in the config.
-            const value: string = config.getProp(sk).replace('token ', '');
-
-            const hint = value.substring(0, 4);
-            input = input.replace(new RegExp(value, 'g'), hint + '-xxxxxx');
-        });
-        return input;
-    }
 }

--- a/packages/portal/frontend/package.json
+++ b/packages/portal/frontend/package.json
@@ -25,7 +25,6 @@
         "@types/restify": "^5.0.7",
         "client-oauth2": "^4.1.0",
         "core-js": "^3.1.3",
-        "dotenv": "5.0.1",
         "flatpickr": "^4.5.1",
         "fs-extra": "^5.0.0",
         "moment": "^2.22.2",


### PR DESCRIPTION
We can't use dotenv in the frontend. Log sanitization added to Log.ts is only used by the backend, but webpack saw it and failed on compiling.
Sanitization function moved from Log to Config (sanitization is of config data).