### PR TITLE
Fixed no container build text output; implemented UI view to display & save logs

### DIFF
--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -3,7 +3,6 @@ import * as Docker from "dockerode";
 import * as http from "http";
 import * as querystring from "querystring";
 import * as restify from "restify";
-import {Stream} from "stream";
 
 import Config, {ConfigKey} from "../../../common/Config";
 import Log from "../../../common/Log";
@@ -226,13 +225,13 @@ export default class RouteHandler {
               };
 
             const handler = (stream: any) => {
-                stream.on('data', (chunk: Stream) => {
+                stream.on('data', (chunk: any) => {
                     Log.trace(chunk.toString());
                 });
-                stream.on('end', (chunk: Stream) => {
+                stream.on('end', (chunk: any) => {
                     Log.info('RouteHandler::postDockerImage(...) - Closing Docker API Connection.');
                 });
-                stream.on('error', (chunk: Stream) => {
+                stream.on('error', (chunk: any) => {
                     Log.error('RouteHandler::postDockerImage(...) Docker Stream ERROR: ' + chunk);
                 });
                 stream.pipe(res);

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -3,6 +3,7 @@ import * as Docker from "dockerode";
 import * as http from "http";
 import * as querystring from "querystring";
 import * as restify from "restify";
+import {Stream} from "stream";
 
 import Config, {ConfigKey} from "../../../common/Config";
 import Log from "../../../common/Log";
@@ -225,14 +226,14 @@ export default class RouteHandler {
               };
 
             const handler = (stream: any) => {
-                stream.on('data', (chunk: any) => {
+                stream.on('data', (chunk: Stream) => {
                     Log.trace(chunk.toString());
                 });
-                stream.on('end', (chunk: any) => {
+                stream.on('end', (chunk: Stream) => {
                     Log.info('RouteHandler::postDockerImage(...) - Closing Docker API Connection.');
                 });
-                stream.on('error', (chunk: any) => {
-                    Log.error('RouteH?andler::postDockerImage(...) Docker Stream ERROR: ' + chunk);
+                stream.on('error', (chunk: Stream) => {
+                    Log.error('RouteHandler::postDockerImage(...) Docker Stream ERROR: ' + chunk);
                 });
                 stream.pipe(res);
             };

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -226,7 +226,7 @@ export default class RouteHandler {
 
             const handler = (stream: any) => {
                 stream.on('data', (chunk: any) => {
-                    Log.trace(chunk.toString());
+                    Log.trace('RouteHandler::postDockerImage(...) - ' + chunk.toString());
                 });
                 stream.on('end', (chunk: any) => {
                     Log.info('RouteHandler::postDockerImage(...) - Closing Docker API Connection.');

--- a/packages/autotest/src/server/RouteHandler.ts
+++ b/packages/autotest/src/server/RouteHandler.ts
@@ -1,5 +1,7 @@
 import * as crypto from "crypto";
 import * as Docker from "dockerode";
+import * as http from "http";
+import * as querystring from "querystring";
 import * as restify from "restify";
 
 import Config, {ConfigKey} from "../../../common/Config";
@@ -200,15 +202,42 @@ export default class RouteHandler {
             const remote = token ? body.remote.replace("https://", "https://" + token + "@") : body.remote;
             const tag = body.tag;
             const file = body.file;
-            const stream = await docker.buildImage(null, {remote, t: tag, dockerfile: file});
-            stream.on("error", (err: Error) => {
-                Log.error("Error building image. " + err.message);
-                res.send(500, "Error building image. " + err.message);
-            });
-            stream.on("end", () => {
-                Log.info("Finished building image.");
-            });
-            stream.pipe(res);
+
+            // Temporary: Work-around of 'dockerode' issue: https://github.com/apocas/dockerode/issues/536
+            // Uncomment when fixed:
+
+            // const stream = await docker.buildImage(null, {remote, t: tag, dockerfile: file});
+            // stream.on("error", (err: Error) => {
+            //     Log.error("Error building image. " + err.message);
+            //     res.send(500, "Error building image. " + err.message);
+            // });
+            // stream.on("end", () => {
+            //     Log.info("Finished building image.");
+            // });
+            // stream.pipe(res);
+
+            const dockerOptions = {remote, t: tag, dockerfile: file};
+            const reqParams = querystring.stringify(dockerOptions);
+            const reqOptions = {
+                socketPath: '/var/run/docker.sock',
+                path: '/v1.24/build?' + reqParams,
+                method: 'POST'
+              };
+
+            const handler = (stream: any) => {
+                stream.on('data', (chunk: any) => {
+                    Log.trace(chunk.toString());
+                });
+                stream.on('end', (chunk: any) => {
+                    Log.info('RouteHandler::postDockerImage(...) - Closing Docker API Connection.');
+                });
+                stream.on('error', (chunk: any) => {
+                    Log.error('RouteH?andler::postDockerImage(...) Docker Stream ERROR: ' + chunk);
+                });
+                stream.pipe(res);
+            };
+            const dockerReq = http.request(reqOptions, handler);
+            dockerReq.end(0);
         } catch (err) {
             Log.error("RouteHandler::postDockerImage(..) - ERROR Building docker image: " + err.message);
             res.send(err.statusCode, err.message);

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -180,6 +180,24 @@
         </ons-dialog>
     </template>
 
+    <template id="dockerBuildDialog.html">
+        <ons-dialog id="adminDockerBuildDialog">
+                <ons-list-header style="text-align: center; font-weight: 700">Build Logs</ons-list-header>
+                <ons-scroller>
+                    <div id="adminDockerBuildDialog-content">
+
+                    </div>
+                </ons-scroller>
+                <ons-button>
+                    Close
+                </ons-button>
+                <ons-button>
+                    Save
+                </ons-button>
+            </div>
+        </ons-dialog>
+    </template>
+
     <template id="config.html">
         <ons-page id="AdminConfig">
             <ons-list id="adminDeliverablesList">

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -188,16 +188,19 @@
                 </ons-scroller>
             </div>
             <div id="adminDockerBuildDialog-footer-container">
-                <a id="adminDockerBuildDialog-footer-close" href="#">
+            <ons-bottom-toolbar>
+                <a style="padding: 10px" id="adminDockerBuildDialog-footer-close">
                     <ons-button>
                         Close
                     </ons-button>
-                </a>
-                <a id="adminDockerBuildDialog-footer-save" href="#">
+                    </a>
+                <a style="padding: 10px" id="adminDockerBuildDialog-footer-save">
                     <ons-button>
                         Save
                     </ons-button>
                 </a>
+            </ons-bottom-toolbar>
+
             </div>
         </ons-dialog>
     </template>

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -182,25 +182,27 @@
 
     <template id="dockerBuildDialog.html">
         <ons-dialog id="adminDockerBuildDialog">
+            <div id="adminDockerBuildDialog-header-container">
                 <ons-list-header style="text-align: center; font-weight: 700">Build Logs</ons-list-header>
-                <ons-scroller>
-                    <div id="adminDockerBuildDialog-content"></div>
+            </div>
+            <div id="adminDockerBuildDialog-logs-container">
+                <ons-scroller id="adminDockerBuildDialog-logs-text" style="max-height: 100%; overflow-y: auto">
                 </ons-scroller>
             </div>
+            </div>
             <div id="adminDockerBuildDialog-footer-container">
-            <ons-bottom-toolbar>
-                <a style="padding: 10px" id="adminDockerBuildDialog-footer-close">
-                    <ons-button>
-                        Close
-                    </ons-button>
+                <ons-bottom-toolbar>
+                    <a style="padding: 10px" id="adminDockerBuildDialog-footer-close">
+                        <ons-button>
+                            Close
+                        </ons-button>
+                        </a>
+                    <a style="padding: 10px" id="adminDockerBuildDialog-footer-save">
+                        <ons-button>
+                            Save
+                        </ons-button>
                     </a>
-                <a style="padding: 10px" id="adminDockerBuildDialog-footer-save">
-                    <ons-button>
-                        Save
-                    </ons-button>
-                </a>
-            </ons-bottom-toolbar>
-
+                </ons-bottom-toolbar>
             </div>
         </ons-dialog>
     </template>

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -185,10 +185,10 @@
             <div id="adminDockerBuildDialog-header-container">
                 <ons-list-header style="text-align: center; font-weight: 700">Build Logs</ons-list-header>
             </div>
-            <div id="adminDockerBuildDialog-logs-container">
-                <ons-scroller id="adminDockerBuildDialog-logs-text" style="max-height: 100%; overflow-y: auto">
-                </ons-scroller>
-            </div>
+            <ons-scroller id="adminDockerBuildDialog-logs-container" style="max-height: 70vh; overflow-y: auto">
+                <div id="adminDockerBuildDialog-logs-text">
+                </div>
+            </ons-scroller>
             </div>
             <div id="adminDockerBuildDialog-footer-container">
                 <ons-bottom-toolbar>

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -184,16 +184,20 @@
         <ons-dialog id="adminDockerBuildDialog">
                 <ons-list-header style="text-align: center; font-weight: 700">Build Logs</ons-list-header>
                 <ons-scroller>
-                    <div id="adminDockerBuildDialog-content">
-
-                    </div>
+                    <div id="adminDockerBuildDialog-content"></div>
                 </ons-scroller>
-                <ons-button>
-                    Close
-                </ons-button>
-                <ons-button>
-                    Save
-                </ons-button>
+            </div>
+            <div id="adminDockerBuildDialog-footer-container">
+                <a id="adminDockerBuildDialog-footer-close" href="#">
+                    <ons-button>
+                        Close
+                    </ons-button>
+                </a>
+                <a id="adminDockerBuildDialog-footer-save" href="#">
+                    <ons-button>
+                        Save
+                    </ons-button>
+                </a>
             </div>
         </ons-dialog>
     </template>

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -109,7 +109,7 @@ stdio viewer Page
     left: 0;
 }
 
-#adminClasslistConfirmHeader .dialog {
+.dialog {
     width: 80%;
 }
 
@@ -123,17 +123,16 @@ stdio viewer Page
     width: 100%;
 }
 
-#adminDockerBuildDialog .dialog {
-    height: 80vh;
-    width: 80%;
-}
-
 #adminDockerBuildDialog .dialog-container {
     overflow-y: auto;
 }
 
 #adminDockerBuildDialog-footer-container ons-bottom-toolbar {
     justify-content: center;
-    align-items: Center;
+    align-items: center;
     display: flex;
+}
+
+#adminDockerBuildDialog .dialog {
+    height: 80vh;
 }

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -123,10 +123,6 @@ stdio viewer Page
     width: 100%;
 }
 
-#adminDockerBuildDialog .dialog-container {
-    overflow-y: auto;
-}
-
 #adminDockerBuildDialog-footer-container ons-bottom-toolbar {
     justify-content: center;
     align-items: center;

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -122,3 +122,8 @@ stdio viewer Page
     text-align: center;
     width: 100%;
 }
+
+#adminDockerBuildDialog .dialog {
+    height: 80vh;
+    width: 80%;
+}

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -131,3 +131,9 @@ stdio viewer Page
 #adminDockerBuildDialog .dialog-container {
     overflow-y: auto;
 }
+
+#adminDockerBuildDialog-footer-container ons-bottom-toolbar {
+    justify-content: center;
+    align-items: Center;
+    display: flex;
+}

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -127,3 +127,7 @@ stdio viewer Page
     height: 80vh;
     width: 80%;
 }
+
+#adminDockerBuildDialog .dialog-container {
+    overflow-y: auto;
+}

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -129,6 +129,11 @@ stdio viewer Page
     display: flex;
 }
 
+#adminDockerBuildDialog-logs-text {
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
 #adminDockerBuildDialog .dialog {
     height: 80vh;
 }

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -324,7 +324,7 @@ export class UI {
             closeButton.onclick = function() { textDialog.hide(); };
             saveButton.onclick = function() {
                 const dateTimeLocal = new Date((new Date().getTime() - new Date().getTimezoneOffset() * 60000)).toISOString();
-                saveButton['download'] = 'Build Log: ' + dateTimeLocal + '.txt';
+                saveButton['download'] = 'Build Log ' + dateTimeLocal + '.txt';
                 saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
              };
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -313,7 +313,7 @@ export class UI {
     public static async templateDisplayText(template: string, text: string = ''): Promise<HTMLDivElement> {
         return ons.createElement(template, {append: true}).then(function(textDialog: any) {
 
-            const textContentDiv = textDialog.querySelector('#adminDockerBuildDialog-content') as HTMLDivElement;
+            const textContentDiv = textDialog.querySelector('#adminDockerBuildDialog-logs-text') as HTMLDivElement;
             textContentDiv.innerText = text;
             textDialog.show();
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -321,7 +321,12 @@ export class UI {
             const saveButton = textDialog.querySelector('#adminDockerBuildDialog-footer-save');
             const closeButton = textDialog.querySelector('#adminDockerBuildDialog-footer-close');
 
+            saveButton['download'] = 'Classy Build Log';
+
             closeButton.onclick = function() { textDialog.hide(); };
+            saveButton.oncontextmenu = function() {
+                saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
+            };
             saveButton.onclick = function() {
                 const dateTimeLocal = new Date((new Date().getTime() - new Date().getTimezoneOffset() * 60000)).toISOString();
                 saveButton['download'] = 'Build Log ' + dateTimeLocal + '.txt';

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -305,6 +305,16 @@ export class UI {
             Log.error('UI::prompt(..) - ERROR: ' + err.message);
         });
     }
+
+    public static async templateDisplayText(template: string, text: string = '', saveButton: boolean): Promise<HTMLDivElement> {
+        return ons.createElement(template, {append: true}).then(function(textDialog: any) {
+            const textContentDiv = textDialog.querySelector('#adminDockerBuildDialog-content') as HTMLDivElement;
+            textContentDiv.innerText = text;
+            textDialog.show();
+            return textContentDiv;
+        });
+    }
+
     public static confirm(message: string, options: {template: string, header?: string}) {
         return ons.notification.confirm(message);
     }

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -306,10 +306,6 @@ export class UI {
         });
     }
 
-    // public static saveText(saveButton: HTMLAnchorElement, innerText: string) {
-    //     saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
-    // }
-
     public static async templateDisplayText(template: string, text: string = ''): Promise<HTMLDivElement> {
         return ons.createElement(template, {append: true}).then(function(textDialog: any) {
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -308,26 +308,24 @@ export class UI {
 
     public static async templateDisplayText(template: string, text: string = ''): Promise<HTMLDivElement> {
         return ons.createElement(template, {append: true}).then(function(textDialog: any) {
-
             const textContentDiv = textDialog.querySelector('#adminDockerBuildDialog-logs-text') as HTMLDivElement;
             textContentDiv.innerText = text;
             textDialog.show();
 
-            // Set listeners on buttons to save text and close dialog box
             const saveButton = textDialog.querySelector('#adminDockerBuildDialog-footer-save');
             const closeButton = textDialog.querySelector('#adminDockerBuildDialog-footer-close');
-
-            saveButton['download'] = 'Classy Build Log';
-
             closeButton.onclick = function() { textDialog.hide(); };
-            saveButton.oncontextmenu = function() {
-                saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
-            };
             saveButton.onclick = function() {
                 const dateTimeLocal = new Date((new Date().getTime() - new Date().getTimezoneOffset() * 60000)).toISOString();
                 saveButton['download'] = 'Build Log ' + dateTimeLocal + '.txt';
                 saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
              };
+            saveButton['download'] = 'Classy Build Log';
+
+            // Updates data when right-clicked to choose custom save filename
+            saveButton.oncontextmenu = function() {
+                saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
+            };
 
             return textContentDiv;
         });

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -306,11 +306,28 @@ export class UI {
         });
     }
 
-    public static async templateDisplayText(template: string, text: string = '', saveButton: boolean): Promise<HTMLDivElement> {
+    // public static saveText(saveButton: HTMLAnchorElement, innerText: string) {
+    //     saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
+    // }
+
+    public static async templateDisplayText(template: string, text: string = ''): Promise<HTMLDivElement> {
         return ons.createElement(template, {append: true}).then(function(textDialog: any) {
+
             const textContentDiv = textDialog.querySelector('#adminDockerBuildDialog-content') as HTMLDivElement;
             textContentDiv.innerText = text;
             textDialog.show();
+
+            // Set listeners on buttons to save text and close dialog box
+            const saveButton = textDialog.querySelector('#adminDockerBuildDialog-footer-save');
+            const closeButton = textDialog.querySelector('#adminDockerBuildDialog-footer-close');
+
+            closeButton.onclick = function() { textDialog.hide(); };
+            saveButton.onclick = function() {
+                const dateTimeLocal = new Date((new Date().getTime() - new Date().getTimezoneOffset() * 60000)).toISOString();
+                saveButton['download'] = 'Build Log: ' + dateTimeLocal + '.txt';
+                saveButton.href = 'data:application/octet-stream,' + encodeURIComponent(textContentDiv.innerText);
+             };
+
             return textContentDiv;
         });
     }

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -562,8 +562,10 @@ export class AdminDeliverablesTab extends AdminPage {
                         const chunkLines = chunk.split("\n")
                             .filter((s) => s !== "")
                             .map((s) => JSON.parse(s))
-                            .filter((s) => s.hasOwnProperty("stream"))
-                            .map((s) => s.stream);
+                            .filter((s) => {
+                                return s.hasOwnProperty("stream") || s.hasOwnProperty("error");
+                            })
+                            .map((s) => s.stream || "\nError code: " + s.errorDetail.code + "\nError Message: " + s.error);
                         output.innerText += chunkLines.join("");
                         output.scrollIntoView(false);
                         lines = lines.concat(chunkLines);

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -545,16 +545,13 @@ export class AdminDeliverablesTab extends AdminPage {
             Log.info("AdminDeliverablesTab::buildDockerImage( .. ) - start");
             const headers = AdminView.getOptions().headers;
             const remote = this.remote;
-            const output = await UI.templateDisplayText('dockerBuildDialog.html',
-                'Initializing Docker Build and buffering. Please wait..\n\n');
+            const output = await UI.templateDisplayText('dockerBuildDialog.html', 'Initializing Docker build. Please wait...\n\n');
 
-            return new Promise<string>(async function(resolve, reject) {
+            return new Promise<string>(function(resolve, reject) {
                 const xhr = new XMLHttpRequest();
                 let lines: string[] = [];
                 let lastIndex = 0;
-
-                xhr.onprogress = async function() {
-
+                xhr.onprogress = function() {
                     try {
                         const currIndex = xhr.responseText.length;
                         if (lastIndex === currIndex) {
@@ -566,9 +563,7 @@ export class AdminDeliverablesTab extends AdminPage {
                         const chunkLines = chunk.split("\n")
                             .filter((s) => s !== "")
                             .map((s) => JSON.parse(s))
-                            .filter((s) => {
-                                return s.hasOwnProperty("stream") || s.hasOwnProperty("error");
-                            })
+                            .filter((s) => s.hasOwnProperty("stream") || s.hasOwnProperty("error"))
                             .map((s) => s.stream || "\nError code: " + s.errorDetail.code + "\nError Message: " + s.error);
                         output.innerText += chunkLines.join("");
                         lines = lines.concat(chunkLines);

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -545,8 +545,8 @@ export class AdminDeliverablesTab extends AdminPage {
             Log.info("AdminDeliverablesTab::buildDockerImage( .. ) - start");
             const headers = AdminView.getOptions().headers;
             const remote = this.remote;
-            const output = await UI.templateDisplayText('dockerBuildDialog.html', 'Initializing Docker Build and buffering. Please wait.. ',
-             true);
+            const output = await UI.templateDisplayText('dockerBuildDialog.html',
+                'Initializing Docker Build and buffering. Please wait..\n\n');
 
             return new Promise<string>(async function(resolve, reject) {
                 const xhr = new XMLHttpRequest();

--- a/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
+++ b/packages/portal/frontend/src/app/views/AdminDeliverablesTab.ts
@@ -320,7 +320,7 @@ export class AdminDeliverablesTab extends AdminPage {
                     fileInput.disabled = true;
                     submit.disabled = true;
 
-                    // UI.showModal();
+                    UI.showModal();
 
                     that.buildDockerImage(context, tag, file).then(function(sha: string) {
                         imageSha = sha;
@@ -564,7 +564,7 @@ export class AdminDeliverablesTab extends AdminPage {
                             .filter((s) => s !== "")
                             .map((s) => JSON.parse(s))
                             .filter((s) => s.hasOwnProperty("stream") || s.hasOwnProperty("error"))
-                            .map((s) => s.stream || "\nError code: " + s.errorDetail.code + "\nError Message: " + s.error);
+                            .map((s) => s.stream || "\n\nError code: " + s.errorDetail.code + "\n\nError Message: " + s.error);
                         output.innerText += chunkLines.join("");
                         lines = lines.concat(chunkLines);
                     } catch (err) {


### PR DESCRIPTION
Here is a fix for the lack of data being returned to the front-end when a container has successfully or unsuccessfully built. 

`Original issue found here`: https://github.com/ubccpsctech/classy/issues/59.
In-depth bug report to `dockerode` found here: https://github.com/apocas/dockerode/issues/536.

Additional Feature: 
- Container error and command that errors is parsed out in the front-end UI so it is easier to understand, if the build fails, what failed in the Docker build.
- Re-based a UI feature branch onto this branch, as it was quickly developed. Here is a screenshot: 

![image](https://user-images.githubusercontent.com/7872295/65919947-953c5400-e392-11e9-9b3b-5adfc1699b10.png)

