### PR TITLE
Uncommenting code block needed for Admin 'Manage Database' feature

### DIFF
--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -1100,7 +1100,6 @@
                     </div>
                 </ons-list-item>
 
-                <!--
                 <ons-list-header>Select Teams to Delete</ons-list-header>
                 <ons-list-item expandable>
                     <div class="left settingIcon">
@@ -1117,7 +1116,6 @@
                         with the team.
                     </div>
                 </ons-list-item>
-                -->
 
                 <ons-list-header>Select Repositories to Delete</ons-list-header>
                 <ons-list-item expandable>


### PR DESCRIPTION
This fixes a null attribute error that occurs due to a commented out HTML block with an ID that the Admin View uses when loading the "Manage Database" feature.

After doing manual tests, I can confirm that deleting a repository and team works through the UI.