### PR TITLE
Feature/parameterize default student delay

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -112,6 +112,10 @@ GH_BOT_USERNAME=autobot
 #####
 #####
 
+## The number of seconds that a student must wait between each grade request feedback from AutoBot.
+## This value is 900 seconds (15 minutes) by default if not set. The back-end will enforce this.
+DEFAULT_STUDENT_DELAY=60
+
 ## The uid for the (non-root) user that should run the containers (if following deploy instructions, should be the uid
 ## for the classy user). Also used by the AutoTest service to configure permissions on directories shared between autotest
 ## and the grading container.

--- a/.env.sample
+++ b/.env.sample
@@ -113,8 +113,8 @@ GH_BOT_USERNAME=autobot
 #####
 
 ## The number of seconds that a student must wait between each grade request feedback from AutoBot.
-## This value is 900 seconds (15 minutes) by default if not set. The back-end will enforce this.
-DEFAULT_STUDENT_DELAY=60
+## This value is a minimum of 900 seconds (15 minutes) if not set below. The back-end will enforce this.
+## MINIMUM_STUDENT_DELAY=60
 
 ## The uid for the (non-root) user that should run the containers (if following deploy instructions, should be the uid
 ## for the classy user). Also used by the AutoTest service to configure permissions on directories shared between autotest

--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -31,6 +31,7 @@ export enum ConfigKey {
     classlist_username = "classlist_username",
     classlist_password = "classlist_password",
 
+    default_student_delay = "default_student_delay",
     publichostname = "publichostname",
 
     backendUrl = "backendUrl",
@@ -101,6 +102,7 @@ export default class Config {
                 classlist_username: process.env.CLASSLIST_USERNAME,
                 classlist_password: process.env.CLASSLIST_PASSWORD,
 
+                default_student_delay: process.env.DEFAULT_STUDENT_DELAY,
                 publichostname: process.env.PUBLICHOSTNAME,
 
                 hostDir:  process.env.HOST_DIR,

--- a/packages/common/Config.ts
+++ b/packages/common/Config.ts
@@ -31,7 +31,7 @@ export enum ConfigKey {
     classlist_username = "classlist_username",
     classlist_password = "classlist_password",
 
-    default_student_delay = "default_student_delay",
+    minimum_student_delay = "minimum_student_delay",
     publichostname = "publichostname",
 
     backendUrl = "backendUrl",
@@ -102,7 +102,7 @@ export default class Config {
                 classlist_username: process.env.CLASSLIST_USERNAME,
                 classlist_password: process.env.CLASSLIST_PASSWORD,
 
-                default_student_delay: process.env.DEFAULT_STUDENT_DELAY,
+                minimum_student_delay: process.env.MINIMUM_STUDENT_DELAY,
                 publichostname: process.env.PUBLICHOSTNAME,
 
                 hostDir:  process.env.HOST_DIR,

--- a/packages/portal/backend/src/controllers/DeliverablesController.ts
+++ b/packages/portal/backend/src/controllers/DeliverablesController.ts
@@ -42,7 +42,7 @@ export class DeliverablesController {
         // }
 
         // the above was pretty complicated
-        const MIN_DELAY = Config.getInstance().getProp(ConfigKey.default_student_delay) || 60 * 15; // ENV setting or 15 minutes
+        const MIN_DELAY = Config.getInstance().getProp(ConfigKey.minimum_student_delay) || 60 * 15; // ENV setting or 15 minutes
         if (deliv.autotest.studentDelay < MIN_DELAY) {
             deliv.autotest.studentDelay = MIN_DELAY;
         }

--- a/packages/portal/backend/src/controllers/DeliverablesController.ts
+++ b/packages/portal/backend/src/controllers/DeliverablesController.ts
@@ -1,3 +1,4 @@
+import Config, {ConfigKey} from '../../../../common/Config';
 import Log from "../../../../common/Log";
 import {AutoTestConfigTransport, DeliverableTransport} from "../../../../common/types/PortalTypes";
 import {Deliverable} from "../Types";
@@ -41,7 +42,7 @@ export class DeliverablesController {
         // }
 
         // the above was pretty complicated
-        const MIN_DELAY = 60 * 15; // 15 minutes
+        const MIN_DELAY = Config.getInstance().getProp(ConfigKey.default_student_delay) || 60 * 15; // ENV setting or 15 minutes
         if (deliv.autotest.studentDelay < MIN_DELAY) {
             deliv.autotest.studentDelay = MIN_DELAY;
         }

--- a/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
+++ b/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
@@ -94,17 +94,26 @@ describe("DeliverablesController", () => {
         let deliv = await dc.getDeliverable(Test.DELIVID1);
         expect(deliv).to.not.be.null;
 
-        // deliv.repoPrefix = '';
-        // deliv.teamPrefix = '';
         deliv.autotest.studentDelay = 60; // 1 minute
+        const valid = await dc.saveDeliverable(deliv);
+        expect(valid).to.not.be.null;
+
+        deliv = await dc.getDeliverable(Test.DELIVID1);
+        expect(deliv).to.not.be.null;
+        expect(deliv.autotest.studentDelay).to.be.greaterThan(120);
+    });
+
+    it("Should enforce custom entered student delay as greater than default", async () => {
+        const db = DatabaseController.getInstance();
+        let deliv = await dc.getDeliverable(Test.DELIVID1);
+        expect(deliv).to.not.be.null;
+        deliv.autotest.studentDelay = 901; // 15 minutes, 1 second
 
         const valid = await dc.saveDeliverable(deliv);
         expect(valid).to.not.be.null;
 
         deliv = await dc.getDeliverable(Test.DELIVID1);
         expect(deliv).to.not.be.null;
-        // expect(deliv.repoPrefix).to.equal(Test.DELIVID1);
-        // expect(deliv.teamPrefix).to.equal('t_' + Test.DELIVID1); // disable this prefix
-        expect(deliv.autotest.studentDelay).to.be.greaterThan(120);
+        expect(deliv.autotest.studentDelay).to.be.equal(901);
     });
 });

--- a/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
+++ b/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
@@ -83,7 +83,7 @@ describe("DeliverablesController", () => {
     });
 
     // this test should be last
-    it("Should enforce constraints on deliverables when saving.", async () => {
+    it("Should enforce default constraint on student delay in deliverables when saving.", async () => {
         const db = DatabaseController.getInstance();
 
         const allPeople = await db.getPeople();

--- a/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
+++ b/packages/portal/backend/test/controllers/DeliverablesControllerSpec.ts
@@ -83,7 +83,7 @@ describe("DeliverablesController", () => {
     });
 
     // this test should be last
-    it("Should enforce default constraint on student delay in deliverables when saving.", async () => {
+    it("Should enforce minimum constraint on student delay in deliverables when saving.", async () => {
         const db = DatabaseController.getInstance();
 
         const allPeople = await db.getPeople();
@@ -103,7 +103,7 @@ describe("DeliverablesController", () => {
         expect(deliv.autotest.studentDelay).to.be.greaterThan(120);
     });
 
-    it("Should enforce custom entered student delay as greater than default", async () => {
+    it("Should enforce custom entered minimum delay between grade requests", async () => {
         const db = DatabaseController.getInstance();
         let deliv = await dc.getDeliverable(Test.DELIVID1);
         expect(deliv).to.not.be.null;

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -957,7 +957,8 @@
                             </div>
                             <div class="expandable-content">
                                 Delay (in seconds) that students must wait between requesting AutoTest feedback.
-                                E.g., 0 for no feedback limit (not recommended!), 43200 (12 hours), 86400 (24 hours).
+                                E.g., 900 (15 minutes), 43200 (12 hours), 86400 (24 hours). Cannot be lower than
+                                15 minutes by default; override default value in environmental config.
                             </div>
                         </ons-list-item>
 

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -958,7 +958,7 @@
                             <div class="expandable-content">
                                 Delay (in seconds) that students must wait between requesting AutoTest feedback.
                                 E.g., 900 (15 minutes), 43200 (12 hours), 86400 (24 hours). Cannot be lower than
-                                15 minutes by default; override default value in environmental config.
+                                15 minutes unless a minimum value is set in the environmental config.
                             </div>
                         </ons-list-item>
 


### PR DESCRIPTION
The UI said that a zero second delay could be set for deliverable grading times, but when setting a time below 900 seconds, it defaulted back to 900 seconds.

Changes: 

- The 900 second time will become the default on Classy instances.
- The default time can be overridden with the `DEFAULT_STUDENT_DELAY` in the environmental config.
- Another test has been written to ensure that times higher than the default are being saved.