### PR TITLE
Taking out runtime Docker container tests, as this logic does not work for all forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,52 +229,6 @@ jobs:
             set -x
             docker-compose up -d 2>&1 | tee -a ${TEST_LOGS}/docker-stdout.log
 
-      # curl -k command turns of SSL cert verification. These are self-signed certs and we just want to know the app is running
-      - run:
-          name: Test to see that Portal front-end static HTML is served
-          command: |
-            set -x
-            STRING="<title>Classy</title>"
-            URL=https://localhost
-            LOG_PATH=${TEST_LOGS}/portal-front-end-test.log
-            curl -k $URL 2>&1 | tee -a $LOG_PATH
-            if cat $LOG_PATH | grep -q "$STRING"; then
-              printf "\n'$STRING' found\n Test passed\n" 2>&1 | tee -a $LOG_PATH
-            else
-              printf "\n'$STRING' not found\n Test failed\n" 2>&1 | tee -a $LOG_PATH
-              exit 1
-            fi
-
-      - run:
-          name: Test to see that Portal back-end API is running in `classytest` mode
-          command: |
-            set -x
-            URL='https://localhost/portal/config'
-            LOG_PATH=${TEST_LOGS}/portal-back-end-test.log
-            curl -ks $URL 2>&1 | tee -a $LOG_PATH
-            CLASSY_ORG=$(cat $LOG_PATH | jq --raw-output '.success.org')
-            if [ "$CLASSY_ORG" != "classytest" ]; then
-              printf "\nClassy organization is $CLASSY_ORG value. Expected 'classytest'.\n Test failed\n" 2>&1 | tee -a $LOG_PATH
-              exit 1
-            else
-              printf "\n$CLASSY_ORG equals classytest. \nTest passed\n" 2>&1 | tee -a $LOG_PATH
-            fi
-
-      - run:
-          name: Test to see that AutoTest is running
-          command: |
-            set -x
-            STRING='Failed to process commit'
-            URL='https://localhost/portal/githubWebhook'
-            LOG_PATH=${TEST_LOGS}/autotest-test.log
-            curl -k -X POST $URL 2>&1 | tee -a $LOG_PATH
-            if cat $LOG_PATH | grep -q "$STRING"; then
-              printf "\n'$STRING' found\n Test passed\n" 2>&1 | tee -a $LOG_PATH
-            else
-              printf "\n'$STRING' not found\n Test failed\n" 2>&1 | tee -a $LOG_PATH
-              exit 1
-            fi
-
       - run:
           name: Shut down containers
           command: docker-compose down 2>&1 | tee -a ${TEST_LOGS}/docker-stdout.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,9 +257,9 @@ workflows:
   version: 2
   ci_tests:
     jobs:
-      - build
+    #   - build
     # Uncomment if you want to run the Docker-compose workflow in regular pushes
-    #   - build_run_stop
+      - build_run_stop
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,9 +257,9 @@ workflows:
   version: 2
   ci_tests:
     jobs:
-    #   - build
+      - build
     # Uncomment if you want to run the Docker-compose workflow in regular pushes
-      - build_run_stop
+    #   - build_run_stop
   nightly:
     triggers:
       - schedule:


### PR DESCRIPTION
This PR removes unnecessary runtime tests for our nightly builds. Fork repositories may have more custom runtime logic if they have additional dependencies for their courses. As these dependencies cannot be customized for all test branches, I think it's reasonable to simplify the nightly build to ONLY test the build process. 

We still meet the key requirement for the nightly builds, which is to test if any upstream package dependencies are breaking. The tests work in this PR after a downstream merge to CPSC310.