### PR TITLE
Adding BOM csv parsing as true to remove leading BOM added by some CS…

### DIFF
--- a/packages/portal/backend/src/server/common/CSVParser.ts
+++ b/packages/portal/backend/src/server/common/CSVParser.ts
@@ -29,7 +29,8 @@ export class CSVParser {
             const options = {
                 columns:          true,
                 skip_empty_lines: true,
-                trim:             true
+                trim:             true,
+                bom:              true // fixes CSV compatibility issue
             };
 
             const parser = parse(options, (err: Error, data: any[]) => {


### PR DESCRIPTION
Fix for issue that makes it appear as if first column does not exist in CSV file to Node JS back-end: https://github.com/ubccpsc/classy/issues/331

Identified problem: A Byte Order Mark (BOM) is a character that appears at some CSV files that denotes encoding qualities in the document. A BOM was added to the beginning of the CSV file in the original bug report, which was parsed by the back-end server and included in the "CSID" key name as a prefix. A different key name was produced for the first column header of the CSV than our business logic required, which resulted in the application thinking that the column did not exist in the CSV file.

Resolution: Remove the BOM header at the beginning of the file (done by `csv-parse` library logic).

There have been apparent issues with the CR/LF lines (https://github.com/ubccpsc/classy/issues/88), which we may consider closing, as changing the CR/LF lines did not result in errors when parsing CSV files in preliminary tests.