### PR TITLE
Updating mocha to remove mkdirp warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "chai": "4.1.2",
         "jsonschema": "1.2.2",
         "lerna": "^2.0.0-rc.5",
-        "mocha": "4.0.1",
+        "mocha": "^7.1.0",
         "ts-node": "4.1.0",
         "tslint": "^5.11.0",
         "typescript": "^3.7.2",

--- a/packages/autotest/package.json
+++ b/packages/autotest/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "5.0.0",
     "jszip": "^3.2.1",
     "xunit-viewer": "^6.0.14",
-    "mocha": "^5.2.0",
+    "mocha": "^7.1.0",
     "mocha-junit-reporter": "^1.17.0",
     "mongodb": "^3.0.2",
     "nyc": "^12.0.2",

--- a/packages/portal/backend/package.json
+++ b/packages/portal/backend/package.json
@@ -40,7 +40,7 @@
         "fs-extra": "^5.0.0",
         "xunit-viewer": "^6.0.14",
         "markdown-table": "^1.1.2",
-        "mocha": "^5.2.0",
+        "mocha": "^7.1.0",
         "mocha-junit-reporter": "^1.17.0",
         "mongodb": "^3.0.3",
         "node-schedule": "^1.3.0",


### PR DESCRIPTION
From issue: https://github.com/ubccpsctech/classy/issues/104

- Removes the mkdirp warnings leftover by an older mocha version.

