### PR TITLE
Updating ConfigTransport type to include list of deliverables with co…

### DIFF
--- a/packages/common/types/PortalTypes.ts
+++ b/packages/common/types/PortalTypes.ts
@@ -8,6 +8,8 @@
 import {AutoTestResult} from "./AutoTestTypes";
 import {ClusteredResult} from "./ContainerTypes";
 
+import {Deliverable} from "../../portal/backend/src/Types";
+
 export interface FailurePayload {
     message: string;
     shouldLogout: boolean; // almost always false
@@ -30,6 +32,7 @@ export interface ClasslistChangesTransport {
     created: StudentTransport[];
     removed: StudentTransport[];
     classlist: StudentTransport[];
+    message: string;
 }
 
 export interface ClasslistChangesTransportPayload {
@@ -46,6 +49,7 @@ export interface ConfigTransport {
     org: string;
     name: string;
     githubAPI: string;
+    studentsFormTeamDelivIds: string[];
 }
 
 export interface CourseTransportPayload {

--- a/packages/portal/backend/src/server/common/ClasslistAgent.ts
+++ b/packages/portal/backend/src/server/common/ClasslistAgent.ts
@@ -66,6 +66,7 @@ export class ClasslistAgent {
         });
 
         const changeReport: ClasslistChangesTransport = {
+            message: 'Successfully uploaded classlist.',
             created: [], // new registrations
             updated: [], // only students whose CWL or lab has changed
             removed: [], // precludes withdrawn students; next step should be to withdraw students who end up appearing here

--- a/packages/portal/backend/src/server/common/GeneralRoutes.ts
+++ b/packages/portal/backend/src/server/common/GeneralRoutes.ts
@@ -64,16 +64,19 @@ export default class GeneralRoutes implements IREST {
         server.put('/portal/classlist', GeneralRoutes.updateClasslist);
     }
 
-    public static getConfig(req: any, res: any, next: any) {
+    public static async getConfig(req: any, res: any, next: any) {
         Log.info('GeneralRoutes::getConfig(..) - start');
 
         const org = Config.getInstance().getProp(ConfigKey.org);
         const name = Config.getInstance().getProp(ConfigKey.name);
         const githubAPI = Config.getInstance().getProp(ConfigKey.githubAPI);
+        const studentsFormTeamDelivIds = (await new DeliverablesController().getAllDeliverables())
+            .filter((d) => d.teamStudentsForm === true)
+            .map((d) => d.id);
 
         let payload: ConfigTransportPayload;
         if (org !== null) {
-            payload = {success: {org: org, name: name, githubAPI: githubAPI}};
+            payload = {success: {org: org, name: name, githubAPI: githubAPI, studentsFormTeamDelivIds}};
             Log.trace('GeneralRoutes::getConfig(..) - sending: ' + JSON.stringify(payload));
             res.send(200, payload);
             return next(false);

--- a/packages/portal/backend/test/server/GeneralRoutesSpec.ts
+++ b/packages/portal/backend/test/server/GeneralRoutesSpec.ts
@@ -10,6 +10,7 @@ import Log from "../../../../common/Log";
 import {Test} from "../../../../common/TestHarness";
 import {ConfigTransportPayload, Payload, TeamFormationTransport} from "../../../../common/types/PortalTypes";
 import {DatabaseController} from "../../src/controllers/DatabaseController";
+import {DeliverablesController} from "../../src/controllers/DeliverablesController";
 import {RepositoryController} from "../../src/controllers/RepositoryController";
 import BackendServer from "../../src/server/BackendServer";
 
@@ -70,7 +71,6 @@ describe('General Routes', function() {
     });
 
     it('Should be able to get config details', async function() {
-
         let response = null;
         let body: ConfigTransportPayload;
         const url = '/portal/config';
@@ -81,11 +81,17 @@ describe('General Routes', function() {
             Log.test('ERROR: ' + err);
         }
         Log.test(response.status + " -> " + JSON.stringify(body));
+        const dc = new DeliverablesController();
+        const studentsFormTeamDelivIds = (await dc.getAllDeliverables())
+            .filter((d) => d.teamStudentsForm === true)
+            .map((d) => d.id);
         expect(response.status).to.equal(200);
         expect(body.success).to.not.be.undefined;
         expect(body.success.org).to.not.be.undefined;
         expect(body.success.org).to.equal(Config.getInstance().getProp(ConfigKey.org)); // valid .org usage
         expect(body.success.name).to.equal(Config.getInstance().getProp(ConfigKey.name));
+        expect(body.success.studentsFormTeamDelivIds.length).to.equal(4);
+        expect(body.success.studentsFormTeamDelivIds).to.eql(studentsFormTeamDelivIds);
     });
 
     it('Should be able to get a person.', async function() {

--- a/packages/portal/frontend/html/admin.html
+++ b/packages/portal/frontend/html/admin.html
@@ -165,6 +165,20 @@
         </ons-page>
     </template>
 
+    <template id="classlistDialog.html">
+        <ons-dialog id="adminClasslistConfirmHeader">
+            <ons-list-header style="text-align: center; font-weight: 700">
+            </ons-list-header>
+            <ons-scroller>
+                <ons-list>
+                </ons-list>
+            </ons-scroller>
+            <ons-button>
+                Close
+            </ons-button>
+        </ons-dialog>
+    </template>
+
     <template id="dockerBuildDialog.html">
         <ons-dialog id="adminDockerBuildDialog">
             <div id="adminDockerBuildDialog-header-container">
@@ -949,7 +963,8 @@
                             </div>
                             <div class="expandable-content">
                                 Delay (in seconds) that students must wait between requesting AutoTest feedback.
-                                E.g., 0 for no feedback limit (not recommended!), 43200 (12 hours), 86400 (24 hours).
+                                E.g., 900 (15 minutes), 43200 (12 hours), 86400 (24 hours). Cannot be lower than
+                                15 minutes unless a minimum value is set in the environmental config.
                             </div>
                         </ons-list-item>
 

--- a/packages/portal/frontend/html/default/student.html
+++ b/packages/portal/frontend/html/default/student.html
@@ -18,7 +18,7 @@
         <ons-list-item>
             <div id="studentRepoTable" style="width:100%;"></div>
         </ons-list-item>
-        <div id="studentSelectPartnerDiv" style="display: none;"> <!-- -->
+        <div id="studentSelectPartnerDiv"> <!-- -->
             <ons-list-header>Select Project Partner</ons-list-header>
             <ons-list-item expandable>
                 <div class="left settingIcon">
@@ -36,11 +36,23 @@
                 </div>
             </ons-list-item>
         </div>
-        <div id="studentPartnerDiv" style="display: none;">
-            <ons-list-header>Project Partner</ons-list-header>
-            <ons-list-item>
-                Your team is&nbsp;<span id="studentPartnerTeamName"></span>.
-                <!--; your teammate is&nbsp;<span id="studentPartnerTeammates"></span>.-->
+        <ons-list-item expandable>
+            <div class="left settingIcon">
+                <ons-icon style="padding-right: 1em;" icon="fa-microchip"></ons-icon>
+                Specify deliverable:
+            </div>
+            <div>
+                <ons-select id="studentSelectDeliverable">
+                </ons-select>
+            </div>
+            <div class="expandable-content">
+                Select the deliverable that you would like to form a team for. Only deliverables configured for student team formation are listed.
+            </div>
+        </ons-list-item>
+        <div id="studentPartnerDiv">
+            <ons-list-header>Current Teams</ons-list-header>
+            <ons-list-item id="studentNotOnTeamMsg">
+                You currently are not on any teams.
             </ons-list-item>
         </div>
     </ons-list>

--- a/packages/portal/frontend/html/style.css
+++ b/packages/portal/frontend/html/style.css
@@ -153,3 +153,16 @@ stdio viewer Page
 #adminDockerBuildDialog .dialog {
     height: 80vh;
 }
+
+/**
+  CSS for Classlist API update change report
+*/
+#adminClasslistConfirmHeader ons-list {
+    overflow-y: auto;
+    height: 80vh;
+}
+
+#adminClasslistConfirmHeader ons-button {
+    text-align: center;
+    width: 100%;
+}

--- a/packages/portal/frontend/src/app/App.ts
+++ b/packages/portal/frontend/src/app/App.ts
@@ -416,11 +416,11 @@ export class App {
                 return json.success;
             } else {
                 Log.error('App::retrieveConfig() - failed: ' + JSON.stringify(json) + ')');
-                return {org: 'ERROR', name: 'ERROR', githubAPI: null};
+                return {org: 'ERROR', name: 'ERROR', githubAPI: null, studentsFormTeamDelivIds: null};
             }
         } else {
             Log.error('App::retrieveConfig() - ERROR');
-            return {org: 'ERROR', name: 'ERROR', githubAPI: null};
+            return {org: 'ERROR', name: 'ERROR', githubAPI: null, studentsFormTeamDelivIds: null};
         }
     }
 

--- a/packages/portal/frontend/src/app/util/UI.ts
+++ b/packages/portal/frontend/src/app/util/UI.ts
@@ -102,6 +102,10 @@ export class UI {
         ons.notification.toast(opts);
     }
 
+    public static createOption(text: string, value: string): HTMLElement {
+        return ons.createElement('<option value=' + value + '>' + text + '</option>');
+    }
+
     public static createListItem(text: string, subtext?: string, tappable?: boolean): HTMLElement {
 
         let prefix = '<ons-list-item style="display: table;">';
@@ -302,7 +306,7 @@ export class UI {
             classlistDialog.show();
         })
         .catch(function(err: Error) {
-            Log.error('UI::prompt(..) - ERROR: ' + err.message);
+            Log.error('UI::prompt(..) - ERROR: ' + err);
         });
     }
 


### PR DESCRIPTION
From issues: https://github.com/ubccpsc/classy/issues/227 and https://github.com/ubccpsc/classy/issues/341.  

NOTE: As deliverable configuration data could include sensitive information in the grading rubric, custom field, or even a Github key in a clone address, we must create a custom list of deliverables where teams are allowed so that the student kind can access this information to create teams with. 

UI Requirements:
- List teams that student is on OR display message that student is not on any teams on
- List ONLY deliverables that student is allowed to form a team for on
- Adding ability to add more than 1 teammate to team on

Back-end Requirements:
- Send a list of Deliverables to the front-end via the ConfigTransport type.

Fix merged into feature branch:
- Includes the missing HTML template that I removed earlier and I re-used some of the logic for the Classlist upload to see if users have been removed, updated, or created.
