### PR TITLE
Feature/tls config

### DIFF
--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -15,6 +15,8 @@ http {
         listen   8443 default_server ssl;
 
         ssl_protocols          TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
 
         ssl_certificate        <%= ENV["SSL_CERT_PATH"] %>;
         ssl_certificate_key    <%= ENV["SSL_KEY_PATH"] %>;

--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -14,6 +14,8 @@ http {
     server {
         listen   8443 default_server ssl;
 
+        ssl_protocols          TLSv1.2 TLSv1.3;
+
         ssl_certificate        <%= ENV["SSL_CERT_PATH"] %>;
         ssl_certificate_key    <%= ENV["SSL_KEY_PATH"] %>;
 

--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -32,6 +32,8 @@ http {
         ssl_certificate        <%= ENV["SSL_CERT_PATH"] %>;
         ssl_certificate_key    <%= ENV["SSL_KEY_PATH"] %>;
 
+        resolver 127.0.0.1;
+
         # pass requests to the portal service (which is automatically defined in the hosts file by docker)
         location / {
             proxy_pass         "https://portal:<%= ENV["BACKEND_PORT"] %>/";

--- a/packages/proxy/nginx.rconf
+++ b/packages/proxy/nginx.rconf
@@ -14,9 +14,20 @@ http {
     server {
         listen   8443 default_server ssl;
 
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
+        ssl_session_tickets off;
+
         ssl_protocols          TLSv1.2 TLSv1.3;
         ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
         ssl_prefer_server_ciphers off;
+
+        # HSTS (ngx_http_headers_module is required) (63072000 seconds)
+        add_header Strict-Transport-Security "max-age=63072000" always;
+
+        # OCSP stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
 
         ssl_certificate        <%= ENV["SSL_CERT_PATH"] %>;
         ssl_certificate_key    <%= ENV["SSL_KEY_PATH"] %>;


### PR DESCRIPTION
- Updates TLS configuration to only use TLS 2.0 or 3.0.
- Updates Cipher configuration to use Mozilla and Google recommended, secure, but commonly supported, ciphers.
- Added explicit session expiration, stapling, and DNS resolution.