### PR TITLE
Adding ts-loader updates

### DIFF
--- a/packages/portal/frontend/package.json
+++ b/packages/portal/frontend/package.json
@@ -33,7 +33,7 @@
         "onsenui": "^2.9.2",
         "restify": "^8.4.0",
         "source-map-loader": "^0.2.4",
-        "ts-loader": "^6.0.0",
+        "ts-loader": "^9.2.3",
         "tsconfig-paths-webpack-plugin": "^3.3.0",
         "tslint": "^5.11.0",
         "typescript": "^3.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,9 +396,9 @@
   integrity sha1-HUp5jlPzUhL9WtTQQFBiAXHNW14=
 
 "@types/mongodb@^3.0.5":
-  version "3.6.17"
-  resolved "https://registry.nlark.com/@types/mongodb/download/@types/mongodb-3.6.17.tgz#a8893654989cb11e9a241858bc530060b6fd126d"
-  integrity sha1-qIk2VJicsR6aJBhYvFMAYLb9Em0=
+  version "3.6.18"
+  resolved "https://registry.nlark.com/@types/mongodb/download/@types/mongodb-3.6.18.tgz#7524c462fc7e3b67892afda8211cd045edee65eb"
+  integrity sha1-dSTEYvx+O2eJKv2oIRzQRe3uZes=
   dependencies:
     "@types/bson" "*"
     "@types/node" "*"
@@ -1009,9 +1009,9 @@ camelcase@^6.0.0:
   integrity sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk=
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001236"
-  resolved "https://registry.nlark.com/caniuse-lite/download/caniuse-lite-1.0.30001236.tgz#0a80de4cdf62e1770bb46a30d884fc8d633e3958"
-  integrity sha1-CoDeTN9i4XcLtGow2IT8jWM+OVg=
+  version "1.0.30001237"
+  resolved "https://registry.nlark.com/caniuse-lite/download/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
+  integrity sha1-S3eDZhUVuOcVH8Y3bP2X8OQnueU=
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -4358,7 +4358,7 @@ tsconfig@^7.0.0:
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.14.1"
-  resolved "https://registry.nlark.com/tslib/download/tslib-1.14.1.tgz?cache=0&sync_timestamp=1618847298334&other_urls=https%3A%2F%2Fregistry.nlark.com%2Ftslib%2Fdownload%2Ftslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  resolved "https://registry.nlark.com/tslib/download/tslib-1.14.1.tgz?cache=0&sync_timestamp=1623450814531&other_urls=https%3A%2F%2Fregistry.nlark.com%2Ftslib%2Fdownload%2Ftslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=
 
 tslint@^5.11.0:
@@ -4436,7 +4436,7 @@ types@^0.1.1:
 
 typescript@^3.5.1, typescript@^3.7.2:
   version "3.9.9"
-  resolved "https://registry.nlark.com/typescript/download/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  resolved "https://registry.nlark.com/typescript/download/typescript-3.9.9.tgz?cache=0&sync_timestamp=1623656021461&other_urls=https%3A%2F%2Fregistry.nlark.com%2Ftypescript%2Fdownload%2Ftypescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
   integrity sha1-5pkFxUvAaB0FGL1NWHzG8tCxpnQ=
 
 uglify-js@^3.1.4:


### PR DESCRIPTION
Eliminates Webpack 5.0 logic deprecation warnings: 

$ /app/node_modules/.bin/webpack
Preparing frontend for: classydev
Loading Classy defaults...
(node:28) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.modules was changed from Array to Set (using Array method 'reduce' is deprecated)
(node:28) [DEP_WEBPACK_MODULE_ERRORS] DeprecationWarning: Module.errors was removed (use getErrors instead)

`ts-loader` fix resolves this issue: https://github.com/TypeStrong/ts-loader/issues/1196