### PR TITLE
Fix: failing nightly build

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "webpack": "^5.38.1"
     },
     "dependencies": {
+        "@types/bson": "^4.2.0",
         "@types/mongodb": "^3.0.5",
         "@types/node-schedule": "^1.2.2",
         "dotenv": "4.0.0",


### PR DESCRIPTION
Here is a hotfix for the failing build that occurred this morning: https://app.circleci.com/pipelines/github/ubccpsctech/classy/1750/workflows/91d54335-a258-4a40-95f9-7b7b0004f916/jobs/2148. Given the start of a semester, I wanted to release this immediately.


