### PR TITLE
Fix: SSL Let's Encrypt root cert issue. Git clone fails in CI/CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: cimg/node:12.22.1
+      - image: cimg/node:12.22.7
       - image: circleci/mongo:3.6
 
       # Specify service dependencies here if necessary


### PR DESCRIPTION
Let's Encrypt upgraded their root cert and the old CircleCI image is breaking the CI/CD tests on a SSL git clone command. This release upgrade the CircleCI image and nothing else.