### PR TITLE
Test/classy dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,4 +20,3 @@ testOutput
 .rysncexclude
 LICENSE
 README.md
-yarn.lock

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "webpack": "^5.38.1"
     },
     "dependencies": {
-        "@types/bson": "^4.2.0",
         "@types/mongodb": "^3.0.5",
         "@types/node-schedule": "^1.2.2",
         "dotenv": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "webpack": "^5.38.1"
     },
     "dependencies": {
+        "@types/bson": "^4.2.0",
         "@types/mongodb": "^3.0.5",
         "@types/node-schedule": "^1.2.2",
         "dotenv": "4.0.0",

--- a/packages/autotest/Dockerfile
+++ b/packages/autotest/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 # The common package requires the .env file directly so we have to pass it through
 COPY .env ./
+COPY yarn.lock ./
 COPY package.json tsconfig.json ./
 COPY packages/common ./packages/common
 COPY packages/portal/backend ./packages/portal/backend

--- a/packages/portal/Dockerfile
+++ b/packages/portal/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 
 # The common package requires the .env file directly so we have to pass it through
 COPY .env ./
+COPY yarn.lock ./
 COPY package.json tsconfig.json .env ./
 COPY packages/common ./packages/common
 COPY packages/portal ./packages/portal


### PR DESCRIPTION
The lockfile is being added to production, which eliminates the needs for the BSON types library added recently and fixes a current issue in production that is blocking the ability to build a grading container. 

See RT#: 153578.