### PR TITLE
Update CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,4 +279,6 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ nightly_build, << pipeline.schedule.name >> ]
     jobs:
-      - build_run_stop
+      - build
+# we really want to know the container is still working (build) not just that it builds (build_run_stop)
+#      - build_run_stop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - build
+      - build_and_test
   nightly:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2.1
 jobs:
-  build:
+  build_and_test:
     docker:
         # Specify service dependencies here if necessary
         # CircleCI maintains a library of pre-built images
@@ -178,7 +178,7 @@ jobs:
             name: Cleaning up
             when: always
 
-  build_run_stop:
+  build_only:
     machine:
       image: ubuntu-2204:current
     working_directory: ~/project
@@ -279,6 +279,6 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ nightly_build, << pipeline.schedule.name >> ]
     jobs:
-      - build
+      - build_and_test
 # we really want to know the container is still working (build) not just that it builds (build_run_stop)
-#      - build_run_stop
+#      - build_only

--- a/packages/autotest/src/autotest/AutoTest.ts
+++ b/packages/autotest/src/autotest/AutoTest.ts
@@ -813,10 +813,7 @@ export abstract class AutoTest implements IAutoTest {
 	 * @private
 	 */
 	private hasCapacity() {
-		if (this.jobs.length < this.numJobs) {
-			return true;
-		}
-		return false;
+		return this.jobs.length < this.numJobs;
 	}
 
 	/**


### PR DESCRIPTION
CircleCI nightly builds only build the containers but don't run the tests. This change make tests run nightly, regardless of whether a change has been made (which is helpful for catching environment changes (specifically to GitHub)).